### PR TITLE
chore(codexbar): zap trash folders

### DIFF
--- a/Casks/codexbar.rb
+++ b/Casks/codexbar.rb
@@ -12,4 +12,16 @@ cask "codexbar" do
   depends_on macos: ">= :sequoia"
 
   app "CodexBar.app"
+  
+  zap trash: [
+    "~/Library/Application Scripts/com.steipete.codexbar.widget",
+    "~/Library/Containers/com.steipete.codexbar.widget",
+    "~/Library/Caches/com.steipete.codexbar",
+    "~/Library/Caches/CodexBar",
+    "~/Library/HTTPStorages/com.steipete.codexbar",
+    "~/Library/HTTPStorages/com.steipete.codexbar.binarycookies",
+    "~/Library/Group Containers/group.com.steipete.codexbar",
+    "~/Library/Preferences/com.steipete.codexbar.plist",
+    "~/Library/WebKit/com.steipete.codexbar",
+  ]
 end


### PR DESCRIPTION
<img width="1076" height="727" alt="Screenshot 2025-12-25 at 21 52 05" src="https://github.com/user-attachments/assets/0204160a-4df6-48e5-914e-09d407b572bc" />

This folder will be used when using `--zap` command prefix like `brew uninstall --cask --zap steipete/tap/codexbar` when uninstalling. Remove all user files with Homebrew is good idea for re-installing, uninstalling cases