### PR TITLE
feat(codexbar): binary link to installing with cask

### DIFF
--- a/Casks/codexbar.rb
+++ b/Casks/codexbar.rb
@@ -12,7 +12,7 @@ cask "codexbar" do
   depends_on macos: ">= :sequoia"
 
   app "CodexBar.app"
-  binary "#{appdir}/CodexBar.app/Contents/Resources/Contents/Helpers/CodexBarCLI"
+  binary "#{appdir}/CodexBar.app/Contents/Helpers/CodexBarCLI", target: "codexbar"
 
   zap trash: [
     "~/Library/Application Scripts/com.steipete.codexbar",


### PR DESCRIPTION
But would be nice if change `CodexBarCLI` to `codexbar` in CodexBar repo