### PR TITLE
chore: upgrade spogo to v0.2.0

### DIFF
--- a/Formula/spogo.rb
+++ b/Formula/spogo.rb
@@ -1,26 +1,26 @@
 class Spogo < Formula
   desc "Spotify power CLI using web cookies"
   homepage "https://github.com/steipete/spogo"
-  version "0.1.0"
+  version "0.2.0"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/steipete/spogo/releases/download/v#{version}/spogo_#{version}_darwin_arm64.tar.gz"
-      sha256 "d9bcccf83abe02f34f907ff2d1cdadf25d4bec8a269bf51fe1c4bcd87580329e"
+      sha256 "4ff7edd6c820c8c444d5a9190825366af47210190073f000d7817e666eada32b"
     else
       url "https://github.com/steipete/spogo/releases/download/v#{version}/spogo_#{version}_darwin_amd64.tar.gz"
-      sha256 "048a5714ef90ef8a716d2bdb77fa9f654432d023d5a06508754e34084ebb4db3"
+      sha256 "4078c4150c50e15d529ee184568ebc98da160bf3ea34f9d6aa29d9ff17da5634"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/steipete/spogo/releases/download/v#{version}/spogo_#{version}_linux_arm64.tar.gz"
-      sha256 "62bcbfb7620b0e6c6d9bf0399c67a378d5e589652acee9f648c1fd2f8bc6795c"
+      sha256 "7c48e7a70cc69a6b5e5d29eba559e235e15f39499d87b0bf7bcebf47cb705a5f"
     else
       url "https://github.com/steipete/spogo/releases/download/v#{version}/spogo_#{version}_linux_amd64.tar.gz"
-      sha256 "ad57d47458277a98ea0c98a00e7a983eb86e83f061d56a12aa40bc6991e169db"
+      sha256 "5e57e0869858b6b4fe36d8553ccee4424685ef84f1ad5e9fc771086f2ffe9947"
     end
   end
 


### PR DESCRIPTION
Upgrades spogo from v0.1.0 to v0.2.0 with updated SHA256 hashes for all platforms (darwin_arm64, darwin_amd64, linux_arm64, linux_amd64).