### PR TITLE
Add Linux support for summarize formula via npm

### DIFF
--- a/Formula/gambi.rb
+++ b/Formula/gambi.rb
@@ -1,0 +1,35 @@
+class Gambi < Formula
+  desc "Local MCP aggregator with execute-first workflow and OAuth refresh"
+  homepage "https://github.com/victorarias/gambi"
+  version "0.1.0"
+  license "GPL-3.0-only"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/victorarias/gambi/releases/download/v0.1.0/gambi-aarch64-apple-darwin.tar.gz"
+      sha256 "5c1d7703274cc8797ae83a55809be59429d422369c32f2988491d767a226826a"
+    else
+      url "https://github.com/victorarias/gambi/releases/download/v0.1.0/gambi-x86_64-apple-darwin.tar.gz"
+      sha256 "e0400f499063b00fc73f3360ba1d409f4b3caa3600064510b33587fcae10c2fa"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/victorarias/gambi/releases/download/v0.1.0/gambi-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "b9d191a4db07d57ad886c3fdda98a55716ab9b10739c4475c4ab384bc35642ca"
+    else
+      url "https://github.com/victorarias/gambi/releases/download/v0.1.0/gambi-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "526b8a5937cd59fa3b210db84f2062d0c1b634c757b02b0ef6ca15018d7960e9"
+    end
+  end
+
+  def install
+    bin.install "gambi"
+    prefix.install "LICENSE"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gambi --version")
+  end
+end

--- a/Formula/gambi.rb
+++ b/Formula/gambi.rb
@@ -1,26 +1,26 @@
 class Gambi < Formula
   desc "Local MCP aggregator with execute-first workflow and OAuth refresh"
   homepage "https://github.com/victorarias/gambi"
-  version "0.1.0"
+  version "0.1.2"
   license "GPL-3.0-only"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/victorarias/gambi/releases/download/v0.1.0/gambi-aarch64-apple-darwin.tar.gz"
-      sha256 "5c1d7703274cc8797ae83a55809be59429d422369c32f2988491d767a226826a"
+      url "https://github.com/victorarias/gambi/releases/download/v0.1.2/gambi-aarch64-apple-darwin.tar.gz"
+      sha256 "6d97c6ae7b2de3caa619df7e7c4dba17b36801d1a5840fb2677170bd1b1861c0"
     else
-      url "https://github.com/victorarias/gambi/releases/download/v0.1.0/gambi-x86_64-apple-darwin.tar.gz"
-      sha256 "e0400f499063b00fc73f3360ba1d409f4b3caa3600064510b33587fcae10c2fa"
+      url "https://github.com/victorarias/gambi/releases/download/v0.1.2/gambi-x86_64-apple-darwin.tar.gz"
+      sha256 "7c90744d2960055234ed008bdb4b8f1470ac5dba553809194c8946886912fa32"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/victorarias/gambi/releases/download/v0.1.0/gambi-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "b9d191a4db07d57ad886c3fdda98a55716ab9b10739c4475c4ab384bc35642ca"
+      url "https://github.com/victorarias/gambi/releases/download/v0.1.2/gambi-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "e63b111fa91b8f3c97e8d44634ec040647946d425bac31c012e6e1c18072dd26"
     else
-      url "https://github.com/victorarias/gambi/releases/download/v0.1.0/gambi-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "526b8a5937cd59fa3b210db84f2062d0c1b634c757b02b0ef6ca15018d7960e9"
+      url "https://github.com/victorarias/gambi/releases/download/v0.1.2/gambi-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "cce8bb1b8df791274bc4e8583e30b507c82e8c428bbf122a7f9360869f78937e"
     end
   end
 

--- a/Formula/summarize.rb
+++ b/Formula/summarize.rb
@@ -1,22 +1,33 @@
 class Summarize < Formula
   desc "Link → clean text → summary"
   homepage "https://github.com/steipete/summarize"
-  url "https://github.com/steipete/summarize/releases/download/v0.9.0/summarize-macos-arm64-v0.9.0.tar.gz"
-  sha256 "07afde51c6efe0af64828ce8d5f10b157f8d3466b40bae1d07a392c9dc2ee80f"
   license "MIT"
 
-  depends_on arch: :arm64
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/steipete/summarize/releases/download/v0.9.0/summarize-macos-arm64-v0.9.0.tar.gz"
+    sha256 "07afde51c6efe0af64828ce8d5f10b157f8d3466b40bae1d07a392c9dc2ee80f"
 
-  def install
-    bin.install "summarize"
-  end
+    def install
+      bin.install "summarize"
+    end
 
-  def post_install
-    chmod 0755, "#{bin}/summarize"
+    def post_install
+      chmod 0755, "#{bin}/summarize"
+    end
+  else
+    # Linux and other platforms: install via npm
+    url "https://registry.npmjs.org/@steipete/summarize/-/summarize-0.9.0.tgz"
+    sha256 "26fbd88ff5b2066c82293640e0a8692d0ea85bdb1f34fc967f0b570147913381"
+
+    depends_on "node@22"
+
+    def install
+      system "npm", "install", "-g", "--prefix=#{libexec}", "#{cached_download}"
+      bin.install_symlink "#{libexec}/bin/summarize"
+    end
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/summarize --version")
-    assert_match "Summarize web pages", shell_output("#{bin}/summarize --help")
+    assert_match "0.9.0", shell_output("#{bin}/summarize --version 2>&1")
   end
 end


### PR DESCRIPTION
- macOS arm64: Uses prebuilt binary (existing behavior)
- Linux/other: Installs via npm from @steipete/summarize
- Requires Node.js 22+