### PR TITLE
Update repobar to 0.2.0

### DIFF
--- a/Casks/repobar.rb
+++ b/Casks/repobar.rb
@@ -1,6 +1,6 @@
 cask "repobar" do
-  version "0.1.1"
-  sha256 "c4f8dda18861505b1fc2e17fa310ce15b79ecd584dd319a4251dd04fe448ccd0"
+  version "0.2.0"
+  sha256 "dcc628c8073185ab0ea669190dfe88828368c307b3f7f21ca38f5ce320ccce2f"
 
   url "https://github.com/steipete/RepoBar/releases/download/v#{version}/RepoBar-#{version}.zip",
       verified: "github.com/steipete/RepoBar/"


### PR DESCRIPTION
Updates RepoBar cask from 0.1.1 to 0.2.0.

## Changes
- Version bump to 0.2.0
- Updated sha256 checksum

## Release notes
v0.2.0 includes authentication improvements (PAT persistence, logout fixes) and various bug fixes.

Release: https://github.com/steipete/RepoBar/releases/tag/v0.2.0