### PR TITLE
Remove Intel architecture restriction from CodexBar cask

### DIFF
--- a/Casks/codexbar.rb
+++ b/Casks/codexbar.rb
@@ -8,7 +8,6 @@ cask "codexbar" do
   desc "Menu bar usage monitor for Codex and Claude"
   homepage "https://codexbar.app/"
 
-  depends_on arch: :arm64
   depends_on macos: ">= :sonoma"
 
   app "CodexBar.app"


### PR DESCRIPTION
## Summary
CodexBar releases are universal binaries (arm64 + x86_64) as of v0.15.0, but the cask still has `depends_on arch: :arm64` which prevents installation on Intel Macs.

## Changes
- Removed `depends_on arch: :arm64` line from `Casks/codexbar.rb`

## Testing
Tested on Intel Mac (x86_64) running macOS Sonoma:
- ✅ Cask installs successfully via Homebrew
- ✅ Downloaded release is a universal binary (contains both x86_64 and arm64)
- ✅ App launches and runs correctly on Intel Mac

## Related
- Changelog entry for v0.15.0 mentions Intel Mac support: "macOS: CodexBar now supports Intel Macs (x86_64 builds + Sonoma fallbacks)."
- Release binaries are built as universal via the build script (`sign-and-notarize.sh` builds for both architectures)