### PR TITLE
fix(cask): remove arm64 arch restriction for codexbar

### DIFF
--- a/Casks/codexbar.rb
+++ b/Casks/codexbar.rb
@@ -8,7 +8,6 @@ cask "codexbar" do
   desc "Menu bar usage monitor for Codex and Claude"
   homepage "https://codexbar.app/"
 
-  depends_on arch: :arm64
   depends_on macos: ">= :sonoma"
 
   app "CodexBar.app"


### PR DESCRIPTION
## Summary

- Remove `depends_on arch: :arm64` from the codexbar cask definition
- Since v0.16.1, CodexBar ships as a **universal binary** (arm64 + x86_64), but the cask still restricts installation to Apple Silicon only
- This prevents Intel Mac users from installing via `brew install --cask steipete/tap/codexbar`

## Verification

Confirmed the downloaded binary is universal:

```
$ file /Applications/CodexBar.app/Contents/MacOS/CodexBar
Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
```

Successfully installed and launched on an Intel Mac (macOS Sonoma) after removing this restriction.