### PR TITLE
repobar: expose CLI on PATH

### DIFF
--- a/Casks/repobar.rb
+++ b/Casks/repobar.rb
@@ -11,6 +11,7 @@ cask "repobar" do
   depends_on macos: ">= :sequoia"
 
   app "RepoBar.app"
+  binary "#{appdir}/RepoBar.app/Contents/MacOS/repobarcli", target: "repobar"
 
   zap trash: [
     "~/Library/Application Support/RepoBar",


### PR DESCRIPTION
After installing via `brew install --cask steipete/tap/repobar`, the `repobar` CLI isn't available in the terminal even though the binary ships inside the app bundle at `RepoBar.app/Contents/MacOS/repobarcli`.

This adds a `binary` stanza so Homebrew symlinks it as `repobar` into the bin path.

Fixes #14