### PR TITLE
fix(wacli): add CGO_CFLAGS for GCC 15+ compatibility

### DIFF
--- a/Formula/wacli.rb
+++ b/Formula/wacli.rb
@@ -22,6 +22,9 @@ class Wacli < Formula
       bin.install "wacli"
     else
       ldflags = "-s -w -X main.version=#{version}"
+      # GCC 15+ with glibc 2.42+ treats missing-braces in Go's runtime/cgo as errors.
+      # See: https://github.com/steipete/wacli/pull/8
+      ENV.append "CGO_CFLAGS", "-Wno-error=missing-braces"
       system "go", "build", "-tags", "sqlite_fts5", *std_go_args(ldflags: ldflags), "./cmd/wacli"
     end
   end


### PR DESCRIPTION
## Summary

- Adds `CGO_CFLAGS=-Wno-error=missing-braces` to the wacli formula's Linux build
- Fixes build failures on GCC 15+ with glibc 2.42+ (Arch Linux, CachyOS, Fedora 42+, etc.)
- Follow-up to the fix already merged in the wacli repo: https://github.com/steipete/wacli/pull/8

## Problem

Go's `runtime/cgo` uses a `pthread_cond_t` initializer pattern that GCC 15+ treats as a `-Werror=missing-braces` error, preventing source builds on modern Linux distros.

## Test plan

- [x] Verified on CachyOS with GCC 15.2.1 and glibc 2.42