### PR TITLE
feat(summarize): add Linux x64 and arm64 support

### DIFF
--- a/Formula/summarize.rb
+++ b/Formula/summarize.rb
@@ -1,11 +1,25 @@
 class Summarize < Formula
   desc "Link → clean text → summary"
   homepage "https://github.com/steipete/summarize"
-  url "https://github.com/steipete/summarize/releases/download/v0.11.1/summarize-macos-arm64-v0.11.1.tar.gz"
-  sha256 "44935e0b159f6cc08eac3e80051e304802ddb65d6c2264b85a48f3d5374f9931"
   license "MIT"
 
-  depends_on arch: :arm64
+  on_macos do
+    on_arm do
+      url "https://github.com/steipete/summarize/releases/download/v0.11.1/summarize-macos-arm64-v0.11.1.tar.gz"
+      sha256 "44935e0b159f6cc08eac3e80051e304802ddb65d6c2264b85a48f3d5374f9931"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/steipete/summarize/releases/download/v0.11.1/summarize-linux-x64-v0.11.1.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    on_arm do
+      url "https://github.com/steipete/summarize/releases/download/v0.11.1/summarize-linux-arm64-v0.11.1.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
 
   def install
     bin.install "summarize"


### PR DESCRIPTION
> **Depends on steipete/summarize#104 — merge that first, then cut a release, then merge this.**

---

## Summary

Restructures `Formula/summarize.rb` to support Linux x64 and arm64 in addition to macOS ARM64, by replacing the single flat `url`/`sha256` + `depends_on arch: :arm64` with `on_macos`/`on_linux` blocks.

**Platforms covered after this change:**

| Platform | Block |
|---|---|
| macOS ARM64 | `on_macos { on_arm }` — existing sha256, unchanged |
| Linux x86_64 | `on_linux { on_intel }` |
| Linux ARM64 | `on_linux { on_arm }` |

## Merge order

1. **Merge steipete/summarize#104** — adds `pnpm build:bun:all:test` (cross-compiles all three platforms from macOS) and updates `scripts/release.sh tap` to rewrite this formula with real sha256s automatically.
2. **Cut a release** — run `pnpm build:bun:all:test`, create the GitHub release with all five assets (3 Bun tarballs + Chrome zip + Firefox zip).
3. **Run `bash scripts/release.sh tap`** — downloads all three tarballs, computes sha256s, rewrites the formula. Commit & push.
4. **Merge this PR** — formula now has real sha256s for all platforms.

## Linux sha256 placeholders

The two Linux `sha256` values are currently `0000…` because no Linux release assets exist yet on `steipete/summarize`. They will be replaced by `scripts/release.sh tap` in step 3 above before this is merged.

## Test plan

- [ ] Merge steipete/summarize#104
- [ ] `pnpm build:bun:all:test` produces all three tarballs
- [ ] Cut release, `bash scripts/release.sh tap` fills in real sha256s
- [ ] On Linux x64: `brew tap steipete/tap && brew install summarize && summarize --version`
- [ ] On Linux arm64: same
- [ ] On macOS: `brew upgrade summarize` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)