### PR TITLE
[bug-fix](formula): rename codexbar to codexbar-cli to avoid conflict with cask and fix brew search issues

### DIFF
--- a/Formula/codexbar-cli.rb
+++ b/Formula/codexbar-cli.rb
@@ -1,8 +1,10 @@
-class Codexbar < Formula
+class CodexBarCLI < Formula
   desc "CodexBar CLI for usage/status output"
   homepage "https://github.com/steipete/CodexBar"
   version "0.19.0"
   license "MIT"
+
+  depends_on :linux
 
   on_linux do
     if Hardware::CPU.arm?


### PR DESCRIPTION
This fixes an issue where the codexbar formula conflicts with the cask of the same name.

Changes:
- Rename formula from codexbar to codexbar-cli
- Update class name to match Homebrew naming conventions
- Restrict formula to Linux using depends_on :linux

This prevents brew search/indexing errors on macOS and avoids name conflicts with the existing cask.