### PR TITLE
chore: bump wacli to v0.5.0

### DIFF
--- a/Formula/wacli.rb
+++ b/Formula/wacli.rb
@@ -1,17 +1,17 @@
 class Wacli < Formula
   desc "WhatsApp CLI built on whatsmeow"
   homepage "https://github.com/steipete/wacli"
-  version "0.2.0"
+  version "0.5.0"
   license "MIT"
 
   on_macos do
     url "https://github.com/steipete/wacli/releases/download/v#{version}/wacli-macos-universal.tar.gz"
-    sha256 "7c42cc5b60caeef44286bb867f235f5d8d09c24419271590d86ca8e4ef385703"
+    sha256 "064ac697aab2e79f08c33e085db95fe5932c1d41f066704728c373199e7a219a"
   end
 
   on_linux do
     url "https://github.com/steipete/wacli/archive/refs/tags/v#{version}.tar.gz"
-    sha256 "80fc82c7f77f63b25434d8f926f0d9d8d57592d971e37495698b757198beac42"
+    sha256 "f6fbd14e82e72263633ce484d92c7d39894797ddcdfb246effe503481f7692b9"
     depends_on "go" => :build
   end
 


### PR DESCRIPTION
Bumps wacli to v0.5.0 across macOS and Linux, resolving the 405 Client Outdated WhatsApp error for Homebrew users.