### PR TITLE
ci: move formula updates into tap

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -75,8 +75,14 @@ def require_single_sha_in_stanza(text: str, stanza: str) -> None:
         )
 
 
-def update_sha_in_stanza(text: str, stanza: str, digest: str) -> str:
+def update_url_and_sha_in_stanza(text: str, stanza: str, url: str, digest: str) -> str:
     require_single_sha_in_stanza(text, stanza)
+    text = replace_once(
+        text,
+        rf'(\n\s*{stanza}\s+do\n(?:.*?\n)*?\s+url\s+")[^"]+(")',
+        rf'\g<1>{url}\2',
+        f"url in {stanza} stanza",
+    )
     return replace_once(
         text,
         rf'(\n\s*{stanza}\s+do\n(?:.*?\n)*?\s+sha256\s+")[^"]+(")',
@@ -126,6 +132,10 @@ def main() -> int:
 
     path = pathlib.Path("Formula") / f"{args.formula}.rb"
     text = path.read_text()
+    has_macos = has_stanza(text, "on_macos")
+    has_linux = has_stanza(text, "on_linux")
+    if has_macos != has_linux:
+        raise SystemExit("formulae with only one platform stanza need manual updates")
     require_single_sha_in_stanza(text, "on_macos")
     require_single_sha_in_stanza(text, "on_linux")
 
@@ -137,15 +147,12 @@ def main() -> int:
         "version",
     )
 
-    if has_stanza(text, "on_macos"):
-        text = update_sha_in_stanza(text, "on_macos", macos_sha)
+    if has_macos:
+        text = update_url_and_sha_in_stanza(text, "on_macos", macos_url, macos_sha)
+        linux_sha = sha256(linux_url)
+        text = update_url_and_sha_in_stanza(text, "on_linux", linux_url, linux_sha)
     else:
         text = update_top_level_url_and_sha(text, macos_url, macos_sha)
-
-    if has_stanza(text, "on_linux"):
-        linux_sha = sha256(linux_url)
-        text = update_sha_in_stanza(text, "on_linux", linux_sha)
-    else:
         linux_sha = None
 
     path.write_text(text)

--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Update a Homebrew formula for a GitHub release.
+
+The script keeps formula-specific editing in this tap. It supports the simple
+single `url`/`sha256` formula shape as well as formulae with separate
+`on_macos` and `on_linux` stanzas such as `Formula/wacli.rb`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import pathlib
+import re
+import sys
+import urllib.request
+
+
+USER_AGENT = "steipete-homebrew-tap-updater"
+
+
+def sha256(url: str) -> str:
+    headers = {"User-Agent": USER_AGENT}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token and url.startswith("https://github.com/"):
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(url, headers=headers)
+    digest = hashlib.sha256()
+    with urllib.request.urlopen(request) as response:
+        while chunk := response.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def replace_once(text: str, pattern: str, replacement: str, description: str) -> str:
+    matches = re.findall(pattern, text, flags=re.MULTILINE | re.DOTALL)
+    if len(matches) != 1:
+        raise SystemExit(f"expected exactly one {description}, found {len(matches)}")
+    return re.sub(pattern, replacement, text, count=1, flags=re.MULTILINE | re.DOTALL)
+
+
+def replace_zero_or_one(text: str, pattern: str, replacement: str, description: str) -> str:
+    matches = re.findall(pattern, text, flags=re.MULTILINE | re.DOTALL)
+    if len(matches) > 1:
+        raise SystemExit(f"expected at most one {description}, found {len(matches)}")
+    if not matches:
+        print(f"no explicit {description}; leaving it unchanged")
+        return text
+    return re.sub(pattern, replacement, text, count=1, flags=re.MULTILINE | re.DOTALL)
+
+
+def update_sha_in_stanza(text: str, stanza: str, digest: str) -> str:
+    return replace_once(
+        text,
+        rf'(\n\s*{stanza}\s+do\n(?:.*?\n)*?\s+sha256\s+")[^"]+(")',
+        rf'\g<1>{digest}\2',
+        f"sha256 in {stanza} stanza",
+    )
+
+
+def has_stanza(text: str, stanza: str) -> bool:
+    return re.search(rf'^\s*{stanza}\s+do\s*$', text, re.MULTILINE) is not None
+
+
+def update_top_level_url_and_sha(text: str, url: str, digest: str) -> str:
+    text = replace_once(
+        text,
+        r'^(\s*url\s+")[^"]+(")',
+        rf'\g<1>{url}\2',
+        "top-level url",
+    )
+    return replace_once(
+        text,
+        r'^(\s*sha256\s+")[^"]+(")',
+        rf'\g<1>{digest}\2',
+        "top-level sha256",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--formula", required=True, help="Formula name, e.g. wacli")
+    parser.add_argument("--tag", required=True, help="Release tag, e.g. v0.7.0")
+    parser.add_argument("--repository", required=True, help="Source repository, e.g. steipete/wacli")
+    parser.add_argument(
+        "--macos-artifact",
+        help="macOS release artifact name. Defaults to <formula>-macos-universal.tar.gz",
+    )
+    parser.add_argument(
+        "--linux-url",
+        help="Linux source/archive URL. Defaults to the GitHub tag archive",
+    )
+    args = parser.parse_args()
+
+    version = args.tag[1:] if args.tag.startswith("v") else args.tag
+    macos_artifact = args.macos_artifact or f"{args.formula}-macos-universal.tar.gz"
+    macos_url = f"https://github.com/{args.repository}/releases/download/{args.tag}/{macos_artifact}"
+    linux_url = args.linux_url or f"https://github.com/{args.repository}/archive/refs/tags/{args.tag}.tar.gz"
+
+    path = pathlib.Path("Formula") / f"{args.formula}.rb"
+    text = path.read_text()
+
+    macos_sha = sha256(macos_url)
+    text = replace_zero_or_one(
+        text,
+        r'^(\s*version\s+")[^"]+(")',
+        rf'\g<1>{version}\2',
+        "version",
+    )
+
+    if has_stanza(text, "on_macos"):
+        text = update_sha_in_stanza(text, "on_macos", macos_sha)
+    else:
+        text = update_top_level_url_and_sha(text, macos_url, macos_sha)
+
+    if has_stanza(text, "on_linux"):
+        linux_sha = sha256(linux_url)
+        text = update_sha_in_stanza(text, "on_linux", linux_sha)
+    else:
+        linux_sha = None
+
+    path.write_text(text)
+
+    print(f"updated {path} to {version}")
+    print(f"macOS: {macos_sha}  {macos_url}")
+    if linux_sha:
+        print(f"Linux: {linux_sha}  {linux_url}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -51,7 +51,32 @@ def replace_zero_or_one(text: str, pattern: str, replacement: str, description: 
     return re.sub(pattern, replacement, text, count=1, flags=re.MULTILINE | re.DOTALL)
 
 
+def stanza_body(text: str, stanza: str) -> str | None:
+    match = re.search(
+        rf'^\s*{stanza}\s+do\s*$\n(?P<body>.*?)(?=^\s*(?:on_macos\s+do|on_linux\s+do|head |def |test do))',
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        return None
+    return match.group("body")
+
+
+def require_single_sha_in_stanza(text: str, stanza: str) -> None:
+    body = stanza_body(text, stanza)
+    if body is None:
+        return
+
+    checksums = re.findall(r'^\s*sha256\s+"[^"]+"', body, flags=re.MULTILINE)
+    if len(checksums) != 1:
+        raise SystemExit(
+            f"expected exactly one sha256 in {stanza} stanza, found {len(checksums)}; "
+            "formulae with multiple architecture-specific checksums need manual updates"
+        )
+
+
 def update_sha_in_stanza(text: str, stanza: str, digest: str) -> str:
+    require_single_sha_in_stanza(text, stanza)
     return replace_once(
         text,
         rf'(\n\s*{stanza}\s+do\n(?:.*?\n)*?\s+sha256\s+")[^"]+(")',
@@ -61,7 +86,7 @@ def update_sha_in_stanza(text: str, stanza: str, digest: str) -> str:
 
 
 def has_stanza(text: str, stanza: str) -> bool:
-    return re.search(rf'^\s*{stanza}\s+do\s*$', text, re.MULTILINE) is not None
+    return stanza_body(text, stanza) is not None
 
 
 def update_top_level_url_and_sha(text: str, url: str, digest: str) -> str:
@@ -101,6 +126,8 @@ def main() -> int:
 
     path = pathlib.Path("Formula") / f"{args.formula}.rb"
     text = path.read_text()
+    require_single_sha_in_stanza(text, "on_macos")
+    require_single_sha_in_stanza(text, "on_linux")
 
     macos_sha = sha256(macos_url)
     text = replace_zero_or_one(

--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -75,12 +75,33 @@ def require_single_sha_in_stanza(text: str, stanza: str) -> None:
         )
 
 
-def update_url_and_sha_in_stanza(text: str, stanza: str, url: str, digest: str) -> str:
+def replace_url_preserving_interpolation(
+    text: str,
+    pattern: str,
+    url: str,
+    version: str,
+    description: str,
+) -> str:
+    matches = list(re.finditer(pattern, text, flags=re.MULTILINE | re.DOTALL))
+    if len(matches) != 1:
+        raise SystemExit(f"expected exactly one {description}, found {len(matches)}")
+
+    match = matches[0]
+    existing_url = match.group("url")
+    if "#{version}" in existing_url and existing_url.replace("#{version}", version) == url:
+        print(f"{description} uses #{{version}} interpolation; leaving it unchanged")
+        return text
+
+    return text[: match.start("url")] + url + text[match.end("url") :]
+
+
+def update_url_and_sha_in_stanza(text: str, stanza: str, url: str, digest: str, version: str) -> str:
     require_single_sha_in_stanza(text, stanza)
-    text = replace_once(
+    text = replace_url_preserving_interpolation(
         text,
-        rf'(\n\s*{stanza}\s+do\n(?:.*?\n)*?\s+url\s+")[^"]+(")',
-        rf'\g<1>{url}\2',
+        rf'(?P<prefix>\n\s*{stanza}\s+do\n(?:.*?\n)*?\s+url\s+")(?P<url>[^"]+)(?P<suffix>")',
+        url,
+        version,
         f"url in {stanza} stanza",
     )
     return replace_once(
@@ -95,11 +116,12 @@ def has_stanza(text: str, stanza: str) -> bool:
     return stanza_body(text, stanza) is not None
 
 
-def update_top_level_url_and_sha(text: str, url: str, digest: str) -> str:
-    text = replace_once(
+def update_top_level_url_and_sha(text: str, url: str, digest: str, version: str) -> str:
+    text = replace_url_preserving_interpolation(
         text,
-        r'^(\s*url\s+")[^"]+(")',
-        rf'\g<1>{url}\2',
+        r'^(?P<prefix>\s*url\s+")(?P<url>[^"]+)(?P<suffix>")',
+        url,
+        version,
         "top-level url",
     )
     return replace_once(
@@ -148,11 +170,11 @@ def main() -> int:
     )
 
     if has_macos:
-        text = update_url_and_sha_in_stanza(text, "on_macos", macos_url, macos_sha)
+        text = update_url_and_sha_in_stanza(text, "on_macos", macos_url, macos_sha, version)
         linux_sha = sha256(linux_url)
-        text = update_url_and_sha_in_stanza(text, "on_linux", linux_url, linux_sha)
+        text = update_url_and_sha_in_stanza(text, "on_linux", linux_url, linux_sha, version)
     else:
-        text = update_top_level_url_and_sha(text, macos_url, macos_sha)
+        text = update_top_level_url_and_sha(text, macos_url, macos_sha, version)
         linux_sha = None
 
     path.write_text(text)

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -4,17 +4,28 @@ on:
   workflow_dispatch:
     inputs:
       formula:
-        description: 'Formula name (e.g., peekaboo)'
+        description: "Formula name (e.g., wacli)"
         required: true
         type: string
       tag:
-        description: 'Release tag to update formula for'
+        description: "Release tag to update formula for"
         required: true
         type: string
       repository:
-        description: 'Source repository (e.g., steipete/peekaboo)'
+        description: "Source repository (e.g., steipete/wacli)"
         required: true
         type: string
+      macos_artifact:
+        description: "macOS artifact name (defaults to <formula>-macos-universal.tar.gz)"
+        required: false
+        type: string
+      linux_url:
+        description: "Linux archive URL (defaults to the GitHub tag archive)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
 
 jobs:
   update-formula:
@@ -22,34 +33,42 @@ jobs:
     steps:
       - name: Checkout tap repository
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Setup Git
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-      
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Update formula
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          FORMULA="${{ github.event.inputs.formula }}"
-          TAG="${{ github.event.inputs.tag }}"
-          REPO="${{ github.event.inputs.repository }}"
-          VERSION="${TAG#v}"
-          
-          # Download the release artifact
-          DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${FORMULA}-macos-universal.tar.gz"
-          curl -L "${DOWNLOAD_URL}" -o "${FORMULA}.tar.gz"
-          
-          # Calculate SHA256
-          SHA256=$(shasum -a 256 "${FORMULA}.tar.gz" | awk '{print $1}')
-          
-          # Update the formula
-          sed -i '' "s/version \".*\"/version \"${VERSION}\"/" "Formula/${FORMULA}.rb"
-          sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256}\"/" "Formula/${FORMULA}.rb"
-          sed -i '' "s|url \".*\"|url \"${DOWNLOAD_URL}\"|" "Formula/${FORMULA}.rb"
-          
-          # Commit and push
+          args=(
+            --formula "${{ inputs.formula }}"
+            --tag "${{ inputs.tag }}"
+            --repository "${{ inputs.repository }}"
+          )
+
+          if [ -n "${{ inputs.macos_artifact }}" ]; then
+            args+=(--macos-artifact "${{ inputs.macos_artifact }}")
+          fi
+
+          if [ -n "${{ inputs.linux_url }}" ]; then
+            args+=(--linux-url "${{ inputs.linux_url }}")
+          fi
+
+          python3 .github/scripts/update_formula.py "${args[@]}"
+
+      - name: Commit and push
+        run: |
+          FORMULA="${{ inputs.formula }}"
+          TAG="${{ inputs.tag }}"
+
+          if git diff --quiet -- "Formula/${FORMULA}.rb"; then
+            echo "Formula/${FORMULA}.rb already up to date"
+            exit 0
+          fi
+
           git add "Formula/${FORMULA}.rb"
-          git commit -m "Update ${FORMULA} to ${TAG}"
+          git commit -m "${FORMULA}: update formula for ${TAG}"
           git push

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -1,4 +1,5 @@
 name: Update Formula
+run-name: Update ${{ inputs.formula }} for ${{ inputs.tag }}${{ inputs.request_id && format(' ({0})', inputs.request_id) || '' }}
 
 on:
   workflow_dispatch:
@@ -21,6 +22,10 @@ on:
         type: string
       linux_url:
         description: "Linux archive URL (defaults to the GitHub tag archive)"
+        required: false
+        type: string
+      request_id:
+        description: "Unique caller-generated ID used to identify this workflow run"
         required: false
         type: string
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ brew install --cask steipete/tap/<name>
 - `repobar` — Menu bar GitHub repo status at a glance
 - `trimmy` — Paste-once, run-once clipboard cleaner for terminal snippets
 
+## Updating Formulae
+
+Run the `Update Formula` workflow with:
+
+- `formula`: formula name, e.g. `wacli`
+- `tag`: release tag, e.g. `v0.7.0`
+- `repository`: source repository, e.g. `steipete/wacli`
+
+The workflow updates regular single-URL formulae and formulae with separate `on_macos` and `on_linux` stanzas. For `wacli`, `steipete/wacli` dispatches this workflow automatically after publishing the macOS release artifact.
+
 ## Update / Uninstall
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Run the `Update Formula` workflow with:
 - `tag`: release tag, e.g. `v0.7.0`
 - `repository`: source repository, e.g. `steipete/wacli`
 
-The workflow updates regular single-URL formulae and formulae with separate `on_macos` and `on_linux` stanzas. For `wacli`, `steipete/wacli` dispatches this workflow automatically after publishing the macOS release artifact.
+The workflow updates regular single-URL formulae and formulae with separate `on_macos` and `on_linux` stanzas when each stanza has exactly one checksum. Formulae with multiple architecture-specific checksums in one stanza still need manual updates. For `wacli`, `steipete/wacli` dispatches this workflow automatically after publishing the macOS release artifact.
 
 ## Update / Uninstall
 


### PR DESCRIPTION
## 🔍 Problem

- Release repositories need tap-specific formula editing to automate Homebrew updates.
- `wacli` needs the tap updater to handle formulae with separate `on_macos` and `on_linux` stanzas.
- Callers need a reliable way to identify and wait for the exact tap workflow run they dispatched.

## 🛠️ Solution

- Move formula update logic into the tap repo's `Update Formula` workflow.
- Add a small Python updater that refreshes the version, URL, macOS artifact SHA256, and Linux archive SHA256 for supported formula shapes.
- Support:
  - regular single-URL formulae
  - formulae with both `on_macos` and `on_linux` stanzas when each stanza has exactly one `url` and one `sha256`
- Fail fast for formulae with multi-arch/multi-checksum stanzas or only one platform stanza, so the workflow never commits a partial formula update.
- Keep optional overrides for macOS artifact names and Linux archive URLs.
- Add an optional `request_id` input and include it in the workflow run name so callers can wait for the exact dispatched run.

## Maintainer setup

- This PR does not require adding a secret to `steipete/homebrew-tap`.
- The workflow commits tap changes with its repo-local `GITHUB_TOKEN`.
- Callers such as `steipete/wacli` need their own token only to dispatch this tap workflow.

## 💬 Review

- Tested the updater against `wacli v0.6.0`; it reproduced the current macOS and Linux SHA256 values.
- Verified unsupported multi-checksum and mixed top-level/platform-stanza formulae fail fast instead of being partially updated.
- Companion `wacli` PR dispatches this workflow after the macOS release artifact is published and waits for the matching `request_id` run.

<sub>
📎 Related: steipete/wacli#168
</sub>
