### PR TITLE
brew: update discrawl to 0.6.2

### DIFF
--- a/Formula/discrawl.rb
+++ b/Formula/discrawl.rb
@@ -1,26 +1,26 @@
 class Discrawl < Formula
   desc "Discord archive CLI for local SQLite search and analysis"
   homepage "https://github.com/steipete/discrawl"
-  version "0.6.1"
+  version "0.6.2"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/steipete/discrawl/releases/download/v#{version}/discrawl_#{version}_darwin_arm64.tar.gz"
-      sha256 "365dec2366cd7ced464346a3d0e2a5b67e2e618d0376b7edb6616529cda5df0c"
+      sha256 "b10ab999b6c0ed91debfa6fc852918dc6d9c31e83a01756dba40656f5e98c97a"
     else
       url "https://github.com/steipete/discrawl/releases/download/v#{version}/discrawl_#{version}_darwin_amd64.tar.gz"
-      sha256 "6394a20ff6c0ae32033eb1b5b2c5640083780267c40e1b41913055d30934e568"
+      sha256 "94366ba4c131612a07da4a15b61ed85e5146f96131ecaa74afc7804ef9bc7751"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/steipete/discrawl/releases/download/v#{version}/discrawl_#{version}_linux_arm64.tar.gz"
-      sha256 "898a42018a71fa38094ab9abc17002b21b238d1780979f9761a5606b60662d03"
+      sha256 "ea48db459c3162c18dfef6e3533f0e0a3a71efd61bcd531fc5b8e5088ed4b47a"
     else
       url "https://github.com/steipete/discrawl/releases/download/v#{version}/discrawl_#{version}_linux_amd64.tar.gz"
-      sha256 "81a8b44e9229fbfd3a25045a4c4de19508012ecd78159f005c55cc4cf69aa112"
+      sha256 "3cd3bb55810beaee1519fc09aa60608d3a04118d306bf0160886562656e30275"
     end
   end
 


### PR DESCRIPTION
Updates the discrawl formula to v0.6.2.\n\nValidation:\n- `brew audit --strict --formula local/discrawl/discrawl`\n- `brew install local/discrawl/discrawl`\n- `discrawl --version` -> `0.6.2`\n- `brew test local/discrawl/discrawl`