### PR TITLE
birdclaw 0.3.0

### DIFF
--- a/Formula/birdclaw.rb
+++ b/Formula/birdclaw.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Birdclaw < Formula
   desc "Local Twitter memory for archives, DMs, likes, bookmarks, and moderation"
   homepage "https://github.com/steipete/birdclaw"
-  url "https://registry.npmjs.org/birdclaw/-/birdclaw-0.2.1.tgz"
-  sha256 "3eefe164cdff72897f286308fd671d86f1dbabad4ca8e87bb421bac166dfeb5b"
+  url "https://registry.npmjs.org/birdclaw/-/birdclaw-0.3.0.tgz"
+  sha256 "3dd439d14d8c590a829ba3d9f1b39bc73ea917c47810f8f34ecac7dd2ab9fcd3"
   license "MIT"
 
   depends_on "node"


### PR DESCRIPTION
Bumps birdclaw to 0.3.0 (published on npm 2026-05-05).

Upstream release: https://github.com/steipete/birdclaw/releases/tag/v0.3.0

### What is in 0.3.0
- New `--min-likes` and `--quality-reason` flags for tweet search quality filtering (thanks @mvanhorn)
- Research mode for turning bookmarked threads into Markdown briefs (thanks @anupamchugh)
- Live home timeline + mention-thread sync commands
- Search snippets for tweet/DM results
- Twitter following counts now stored on profiles + included in JSONL backups

### Verification
- Source: `https://registry.npmjs.org/birdclaw/-/birdclaw-0.3.0.tgz`
- `sha256 3dd439d14d8c590a829ba3d9f1b39bc73ea917c47810f8f34ecac7dd2ab9fcd3` (verified locally with `shasum -a 256`)
- Diff is mechanical: URL + sha256 only, no other formula changes needed