### PR TITLE
fix: keep wacli formula metadata on moved repo

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -246,6 +246,23 @@ def update_top_level_url_and_sha(text: str, url: str, digest: str, version: str)
     )
 
 
+def update_repository_metadata(text: str, repository: str) -> str:
+    homepage = f"https://github.com/{repository}"
+    head = f"{homepage}.git"
+    text = replace_zero_or_one(
+        text,
+        r'^(?P<prefix>\s*homepage\s+")[^"]+(?P<suffix>")',
+        rf'\g<prefix>{homepage}\g<suffix>',
+        "homepage",
+    )
+    return replace_zero_or_one(
+        text,
+        r'^(?P<prefix>\s*head\s+")[^"]+(?P<suffix>"(?:,\s*branch:\s*"[^"]+")?)',
+        rf'\g<prefix>{head}\g<suffix>',
+        "head",
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--formula", required=True, help="Formula name, e.g. wacli")
@@ -305,6 +322,7 @@ def main() -> int:
         print(f"created {path}")
 
     text = path.read_text()
+    text = update_repository_metadata(text, args.repository)
     has_macos = has_stanza(text, "on_macos")
     has_linux = has_stanza(text, "on_linux")
     targets = ("darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64")

--- a/Formula/wacli.rb
+++ b/Formula/wacli.rb
@@ -1,6 +1,6 @@
 class Wacli < Formula
   desc "WhatsApp CLI built on whatsmeow"
-  homepage "https://github.com/steipete/wacli"
+  homepage "https://github.com/openclaw/wacli"
   version "0.8.1"
   license "MIT"
 
@@ -15,7 +15,7 @@ class Wacli < Formula
     depends_on "go" => :build
   end
 
-  head "https://github.com/steipete/wacli.git", branch: "main"
+  head "https://github.com/openclaw/wacli.git", branch: "main"
 
   def install
     if File.exist?("wacli")


### PR DESCRIPTION
## Summary

This keeps the `wacli` formula metadata pointed at the moved `openclaw/wacli` repository now that the tap formula has already advanced to v0.8.1.

This is intentionally not a manual version bump. The release automation already updated the artifact URLs and SHAs, but existing `homepage` and `head` lines sit outside the updater's URL/SHA rewrite path and were left pointing at `steipete/wacli`. The updater now rewrites those metadata fields from the dispatched `repository` input so future automated releases keep the formula consistent after repository moves.

## Verification

- `ruby -c Formula/wacli.rb`
- `python3 -m py_compile .github/scripts/update_formula.py`
- Metadata rewrite smoke test for `update_repository_metadata(..., "openclaw/wacli")`
