### PR TITLE
Support architecture-specific formula updates

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -19,6 +19,7 @@ import urllib.request
 
 
 USER_AGENT = "steipete-homebrew-tap-updater"
+ARCH_TARGETS = ("darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64")
 
 
 def sha256(url: str) -> str:
@@ -218,6 +219,127 @@ def update_url_and_sha_in_stanza(text: str, stanza: str, url: str, digest: str, 
     return text[: match.start("body")] + body + text[match.end("body") :]
 
 
+def target_from_cpu_block(stanza: str, body: str, pair: re.Match[str]) -> str | None:
+    prefix = body[: pair.start()]
+    last_arm = prefix.rfind("on_arm do")
+    last_intel = prefix.rfind("on_intel do")
+    if last_arm == -1 and last_intel == -1:
+        return None
+
+    platform = "darwin" if stanza == "on_macos" else "linux"
+    arch = "arm64" if last_arm > last_intel else "amd64"
+    return f"{platform}_{arch}"
+
+
+def release_artifact_url(
+    repository: str,
+    tag: str,
+    formula: str,
+    version: str,
+    template: str,
+    aliases: dict[str, str],
+    target: str,
+) -> str:
+    artifact_target = aliases.get(target, target)
+    artifact = template.format(
+        formula=formula,
+        version=version,
+        tag=tag,
+        target=artifact_target,
+    )
+    return f"https://github.com/{repository}/releases/download/{tag}/{artifact}"
+
+
+def update_url_and_sha_by_target_blocks(
+    text: str,
+    repository: str,
+    tag: str,
+    formula: str,
+    version: str,
+    template: str,
+    aliases: dict[str, str],
+    digest_for_url=sha256,
+) -> tuple[str, set[str]]:
+    updated_targets: set[str] = set()
+
+    for stanza in ("on_macos", "on_linux"):
+        match = stanza_match(text, stanza)
+        if not match:
+            continue
+
+        body = match.group("body")
+        replacements: list[tuple[int, int, str]] = []
+        for pair in iter_url_sha_pairs(body):
+            target = target_from_cpu_block(stanza, body, pair)
+            if not target:
+                continue
+
+            url = release_artifact_url(repository, tag, formula, version, template, aliases, target)
+            digest = digest_for_url(url)
+            existing_url = pair.group("url")
+            replacement_url = existing_url if "#{version}" in existing_url and existing_url.replace("#{version}", version) == url else url
+            replacement = (
+                f'{pair.group("prefix")}{replacement_url}'
+                f'{pair.group("middle")}{digest}{pair.group("suffix")}'
+            )
+            replacements.append((pair.start(), pair.end(), replacement))
+            updated_targets.add(target)
+
+        for start, end, replacement in reversed(replacements):
+            body = body[:start] + replacement + body[end:]
+
+        text = text[: match.start("body")] + body + text[match.end("body") :]
+
+    return text, updated_targets
+
+
+def update_url_and_sha_by_classified_targets(
+    text: str,
+    classified_pairs: list[tuple[re.Match[str], str | None]],
+    repository: str,
+    tag: str,
+    formula: str,
+    version: str,
+    template: str,
+    aliases: dict[str, str],
+    target_url_count: int,
+    path: pathlib.Path,
+    digest_for_url=sha256,
+) -> tuple[str, set[str]]:
+    replacements: list[tuple[int, int, str]] = []
+    seen_targets: set[str] = set()
+    for match, target in classified_pairs:
+        if not target:
+            continue
+        url = release_artifact_url(
+            repository,
+            tag,
+            formula,
+            version,
+            template,
+            aliases,
+            target,
+        )
+        digest = digest_for_url(url)
+        existing_url = match.group("url")
+        replacement_url = url
+        if "#{version}" in existing_url and existing_url.replace("#{version}", version) == url:
+            replacement_url = existing_url
+        replacement = (
+            f'{match.group("prefix")}{replacement_url}'
+            f'{match.group("middle")}{digest}{match.group("suffix")}'
+        )
+        replacements.append((match.start(), match.end(), replacement))
+        seen_targets.add(target)
+        print(f"{target}: {digest}  {url}")
+    for target in sorted(set(ARCH_TARGETS).intersection(seen_targets ^ set(ARCH_TARGETS))):
+        if target_url_count >= 4:
+            raise SystemExit(f"failed to update {target} in {path}")
+    for start, end, replacement in reversed(replacements):
+        text = text[:start] + replacement + text[end:]
+    return text, seen_targets
+
+
 def has_stanza(text: str, stanza: str) -> bool:
     return stanza_body(text, stanza) is not None
 
@@ -405,7 +527,6 @@ def main() -> int:
     text = update_repository_metadata(text, args.repository)
     has_macos = has_stanza(text, "on_macos")
     has_linux = has_stanza(text, "on_linux")
-    targets = ("darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64")
     url_sha_pairs = iter_url_sha_pairs(text)
     classified_pairs = [(match, classify_target(match.group("url"), target_aliases, version)) for match in url_sha_pairs]
     target_url_count = sum(1 for _, target in classified_pairs if target)
@@ -415,38 +536,32 @@ def main() -> int:
 
     text = update_version(text, version)
 
-    if has_target_urls:
+    if args.artifact_template and has_macos and has_linux:
+        text, seen_targets = update_url_and_sha_by_target_blocks(
+            text,
+            args.repository,
+            args.tag,
+            args.formula,
+            version,
+            args.artifact_template,
+            target_aliases,
+        )
+        for target in sorted(set(ARCH_TARGETS) - seen_targets):
+            raise SystemExit(f"failed to update {target} in {path}")
+    elif has_target_urls:
         template = args.artifact_template or "{formula}_{version}_{target}.tar.gz"
-        replacements: list[tuple[int, int, str]] = []
-        seen_targets: set[str] = set()
-        for match, target in classified_pairs:
-            if not target:
-                continue
-            artifact_target = target_aliases.get(target, target)
-            artifact = template.format(
-                formula=args.formula,
-                version=version,
-                tag=args.tag,
-                target=artifact_target,
-            )
-            url = f"https://github.com/{args.repository}/releases/download/{args.tag}/{artifact}"
-            digest = sha256(url)
-            existing_url = match.group("url")
-            replacement_url = url
-            if "#{version}" in existing_url and existing_url.replace("#{version}", version) == url:
-                replacement_url = existing_url
-            replacement = (
-                f'{match.group("prefix")}{replacement_url}'
-                f'{match.group("middle")}{digest}{match.group("suffix")}'
-            )
-            replacements.append((match.start(), match.end(), replacement))
-            seen_targets.add(target)
-            print(f"{target}: {digest}  {url}")
-        for target in sorted(set(targets).intersection(seen_targets ^ set(targets))):
-            if target_url_count >= 4:
-                raise SystemExit(f"failed to update {target} in {path}")
-        for start, end, replacement in reversed(replacements):
-            text = text[:start] + replacement + text[end:]
+        text, _ = update_url_and_sha_by_classified_targets(
+            text,
+            classified_pairs,
+            args.repository,
+            args.tag,
+            args.formula,
+            version,
+            template,
+            target_aliases,
+            target_url_count,
+            path,
+        )
 
         if args.linux_url:
             linux_sha = sha256(linux_url)

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -111,6 +111,200 @@ end
 
         self.assertTrue(update_formula.uses_stanza_url_mode(text, "0.9.2"))
 
+    def test_converts_platform_stanzas_to_architecture_artifacts(self) -> None:
+        text = '''class Wacli < Formula
+  on_macos do
+    on_arm do
+      url "https://github.com/openclaw/wacli/releases/download/v0.9.2/wacli-macos-universal.tar.gz"
+      sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    end
+
+    on_intel do
+      url "https://github.com/openclaw/wacli/releases/download/v0.9.2/wacli-macos-universal.tar.gz"
+      sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/openclaw/wacli/archive/refs/tags/v0.9.2.tar.gz"
+      sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    end
+
+    on_intel do
+      url "https://github.com/openclaw/wacli/archive/refs/tags/v0.9.2.tar.gz"
+      sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    end
+  end
+
+  def install
+  end
+end
+'''
+
+        def digest(url: str) -> str:
+            return {
+                "https://github.com/steipete/wacli/releases/download/v0.9.3/wacli-darwin-arm64.tar.gz": "1" * 64,
+                "https://github.com/steipete/wacli/releases/download/v0.9.3/wacli-darwin-amd64.tar.gz": "2" * 64,
+                "https://github.com/steipete/wacli/releases/download/v0.9.3/wacli-linux-arm64.tar.gz": "3" * 64,
+                "https://github.com/steipete/wacli/releases/download/v0.9.3/wacli-linux-amd64.tar.gz": "4" * 64,
+            }[url]
+
+        updated, targets = update_formula.update_url_and_sha_by_target_blocks(
+            text,
+            "steipete/wacli",
+            "v0.9.3",
+            "wacli",
+            "0.9.3",
+            "wacli-{target}.tar.gz",
+            {
+                "darwin_amd64": "darwin-amd64",
+                "darwin_arm64": "darwin-arm64",
+                "linux_amd64": "linux-amd64",
+                "linux_arm64": "linux-arm64",
+            },
+            digest,
+        )
+
+        self.assertEqual(targets, {"darwin_arm64", "darwin_amd64", "linux_arm64", "linux_amd64"})
+        self.assertIn("wacli-darwin-arm64.tar.gz", updated)
+        self.assertIn("wacli-darwin-amd64.tar.gz", updated)
+        self.assertIn("wacli-linux-arm64.tar.gz", updated)
+        self.assertIn("wacli-linux-amd64.tar.gz", updated)
+        self.assertNotIn("wacli-macos-universal.tar.gz", updated)
+        self.assertNotIn("archive/refs/tags", updated)
+
+    def test_updates_existing_architecture_artifact_urls(self) -> None:
+        text = '''class Wacli < Formula
+  on_macos do
+    on_arm do
+      url "https://github.com/steipete/wacli/releases/download/v0.9.2/wacli-darwin-arm64.tar.gz"
+      sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    end
+
+    on_intel do
+      url "https://github.com/steipete/wacli/releases/download/v0.9.2/wacli-darwin-amd64.tar.gz"
+      sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/steipete/wacli/releases/download/v0.9.2/wacli-linux-arm64.tar.gz"
+      sha256 "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    end
+
+    on_intel do
+      url "https://github.com/steipete/wacli/releases/download/v0.9.2/wacli-linux-amd64.tar.gz"
+      sha256 "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    end
+  end
+
+  def install
+  end
+end
+'''
+
+        aliases = {
+            "darwin_amd64": "darwin-amd64",
+            "darwin_arm64": "darwin-arm64",
+            "linux_amd64": "linux-amd64",
+            "linux_arm64": "linux-arm64",
+        }
+
+        def digest(url: str) -> str:
+            return {
+                "https://github.com/steipete/wacli/releases/download/v0.9.3/wacli-darwin-arm64.tar.gz": "1" * 64,
+                "https://github.com/steipete/wacli/releases/download/v0.9.3/wacli-darwin-amd64.tar.gz": "2" * 64,
+                "https://github.com/steipete/wacli/releases/download/v0.9.3/wacli-linux-arm64.tar.gz": "3" * 64,
+                "https://github.com/steipete/wacli/releases/download/v0.9.3/wacli-linux-amd64.tar.gz": "4" * 64,
+            }[url]
+
+        pairs = update_formula.iter_url_sha_pairs(text)
+        classified = [(match, update_formula.classify_target(match.group("url"), aliases, "0.9.3")) for match in pairs]
+
+        updated, targets = update_formula.update_url_and_sha_by_classified_targets(
+            text,
+            classified,
+            "steipete/wacli",
+            "v0.9.3",
+            "wacli",
+            "0.9.3",
+            "wacli-{target}.tar.gz",
+            aliases,
+            len(classified),
+            pathlib.Path("Formula/wacli.rb"),
+            digest,
+        )
+
+        self.assertEqual(targets, {"darwin_arm64", "darwin_amd64", "linux_arm64", "linux_amd64"})
+        self.assertNotIn("v0.9.2", updated)
+        self.assertIn("wacli-darwin-arm64.tar.gz", updated)
+        self.assertIn("wacli-darwin-amd64.tar.gz", updated)
+        self.assertIn("wacli-linux-arm64.tar.gz", updated)
+        self.assertIn("wacli-linux-amd64.tar.gz", updated)
+        self.assertIn('sha256 "' + "1" * 64 + '"', updated)
+        self.assertIn('sha256 "' + "2" * 64 + '"', updated)
+        self.assertIn('sha256 "' + "3" * 64 + '"', updated)
+        self.assertIn('sha256 "' + "4" * 64 + '"', updated)
+
+    def test_rejects_missing_target_when_existing_architecture_urls_are_expected(self) -> None:
+        text = '''class Wacli < Formula
+  on_macos do
+    on_arm do
+      url "https://github.com/steipete/wacli/releases/download/v0.9.2/wacli-darwin-arm64.tar.gz"
+      sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    end
+
+    on_intel do
+      url "https://github.com/steipete/wacli/releases/download/v0.9.2/wacli-darwin-amd64.tar.gz"
+      sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/steipete/wacli/releases/download/v0.9.2/wacli-linux-arm64.tar.gz"
+      sha256 "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    end
+
+    on_intel do
+      url "https://github.com/steipete/wacli/releases/download/v0.9.2/wacli-linux-arm64.tar.gz"
+      sha256 "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    end
+  end
+
+  def install
+  end
+end
+'''
+
+        aliases = {
+            "darwin_amd64": "darwin-amd64",
+            "darwin_arm64": "darwin-arm64",
+            "linux_amd64": "linux-amd64",
+            "linux_arm64": "linux-arm64",
+        }
+        pairs = update_formula.iter_url_sha_pairs(text)
+        classified = [(match, update_formula.classify_target(match.group("url"), aliases, "0.9.3")) for match in pairs]
+
+        with self.assertRaises(SystemExit) as raised:
+            update_formula.update_url_and_sha_by_classified_targets(
+                text,
+                classified,
+                "steipete/wacli",
+                "v0.9.3",
+                "wacli",
+                "0.9.3",
+                "wacli-{target}.tar.gz",
+                aliases,
+                len(classified),
+                pathlib.Path("Formula/wacli.rb"),
+                lambda _url: "1" * 64,
+            )
+
+        self.assertIn("failed to update linux_amd64", str(raised.exception))
+
     def test_updates_cask_version_and_checksum_preserving_interpolated_url(self) -> None:
         text = '''cask "codexbar" do
   version "0.26.1"


### PR DESCRIPTION
## Summary

- Teach the formula updater to convert platform stanzas with on_arm / on_intel blocks into architecture-specific release artifact URLs when --artifact-template is provided.
- Reuse the artifact URL construction for already target-specific formula updates.
- Add a regression test covering a wacli-style formula migrating from shared stanza URLs to per-architecture assets.

## Testing

- python3 -m unittest discover -s tests -v