### PR TITLE
fix(casks): use symbol form for depends_on macos

### DIFF
--- a/Casks/blackbar.rb
+++ b/Casks/blackbar.rb
@@ -14,7 +14,7 @@ cask "blackbar" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "BlackBar.app"
 

--- a/Casks/codexbar.rb
+++ b/Casks/codexbar.rb
@@ -8,7 +8,7 @@ cask "codexbar" do
   desc "Menu bar usage monitor for Codex and Claude"
   homepage "https://codexbar.app/"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "CodexBar.app"
   binary "#{appdir}/CodexBar.app/Contents/Helpers/CodexBarCLI", target: "codexbar"

--- a/Casks/repobar.rb
+++ b/Casks/repobar.rb
@@ -8,7 +8,7 @@ cask "repobar" do
   desc "Menu bar dashboard for GitHub repository health"
   homepage "https://repobar.app/"
 
-  depends_on macos: ">= :sequoia"
+  depends_on macos: :sequoia
 
   app "RepoBar.app"
   binary "#{appdir}/RepoBar.app/Contents/MacOS/repobarcli", target: "repobar"

--- a/Casks/trimmy.rb
+++ b/Casks/trimmy.rb
@@ -8,7 +8,7 @@ cask "trimmy" do
   homepage "https://github.com/steipete/Trimmy"
 
   depends_on arch: :arm64
-  depends_on macos: ">= :sequoia"
+  depends_on macos: :sequoia
 
   app "Trimmy.app"
 


### PR DESCRIPTION
## What

Replace the deprecated string-comparison form of `depends_on macos:` with the symbol form across four casks:

| Cask | Before | After |
|------|--------|-------|
| blackbar | `depends_on macos: ">= :sonoma"` | `depends_on macos: :sonoma` |
| codexbar | `depends_on macos: ">= :sonoma"` | `depends_on macos: :sonoma` |
| repobar | `depends_on macos: ">= :sequoia"` | `depends_on macos: :sequoia` |
| trimmy | `depends_on macos: ">= :sequoia"` | `depends_on macos: :sequoia` |

## Why

Homebrew now emits a deprecation warning on every operation that touches the tap:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sonoma` instead.
```

The bare symbol form already means ">= that version", so this is semantics-preserving — it just silences the warning.

## Maintainer proof

Validated on the rebased PR branch at `1d667b061ee29bbcdddc5167bef06b5b92129dfa` with Homebrew `5.1.15-221-g259096e`.

Deprecated forms scan:

```console
$ rg -n 'depends_on\s+macos:\s*"[<>=]' Casks Formula .github tests README.md
# no matches
```

Homebrew OSDependsOn RuboCop check:

```console
$ brew style --only-cops Homebrew/OSDependsOn Casks/blackbar.rb Casks/codexbar.rb Casks/repobar.rb Casks/trimmy.rb
Inspecting 4 files
....

4 files inspected, no offenses detected
```

Homebrew cask parser/auditor proof using `FromContentLoader`, without mutating the installed tap:

```console
$ brew ruby -e 'require "cask/cask_loader"; require "cask/auditor"; require "tap"; tap = Tap.fetch("steipete", "tap"); failed = false; ARGV.each do |path| content = Pathname(path).read(encoding: "UTF-8"); c = Cask::CaskLoader::FromContentLoader.new(content, tap: tap).load(config: nil); errors = Cask::Auditor.audit(c, audit_strict: true, quarantine: true, any_named_args: true).to_a; if errors.empty?; puts "#{path}: audit ok"; else; failed = true; puts "#{path}: audit errors"; errors.each { |e| puts "  #{e}" }; end; end; exit(failed ? 1 : 0)' Casks/blackbar.rb Casks/codexbar.rb Casks/repobar.rb Casks/trimmy.rb
Casks/blackbar.rb: audit ok
Casks/codexbar.rb: audit ok
Casks/repobar.rb: audit ok
Casks/trimmy.rb: audit ok
```

Repo automation test:

```console
$ python3 -m unittest tests/test_update_formula.py
Ran 6 tests in 0.001s
OK
```

Autoreview:

```console
$ /Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main
autoreview clean: no accepted/actionable findings reported
```
