### PR TITLE
codexbar: use symbol form for depends_on macos

### DIFF
--- a/Casks/codexbar.rb
+++ b/Casks/codexbar.rb
@@ -8,7 +8,7 @@ cask "codexbar" do
   desc "Menu bar usage monitor for Codex and Claude"
   homepage "https://codexbar.app/"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "CodexBar.app"
   binary "#{appdir}/CodexBar.app/Contents/Helpers/CodexBarCLI", target: "codexbar"


### PR DESCRIPTION
## Summary

Replaces the deprecated string-comparison form of `depends_on macos:` in the `codexbar` cask with the symbol form Homebrew now recommends.

```ruby
# before
depends_on macos: ">= :sonoma"
# after
depends_on macos: :sonoma
```

The symbol form already carries the ">= this version" semantics, so the dependency constraint is unchanged — Sonoma or newer.

## Why

Homebrew 5.1.x emits this on **every** `brew` operation for anyone who has this tap installed:

> Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sonoma` instead.
>   /opt/homebrew/Library/Taps/steipete/homebrew-tap/Casks/codexbar.rb:11

This change silences it.

## Test plan

- [ ] `brew style steipete/homebrew-tap` passes
- [ ] `brew audit --cask steipete/tap/codexbar` passes
- [ ] No deprecation warning on `brew update` / `brew doctor`