### PR TITLE
Fix deprecated depends_on macos string comparison syntax

### DIFF
--- a/Casks/blackbar.rb
+++ b/Casks/blackbar.rb
@@ -14,7 +14,7 @@ cask "blackbar" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "BlackBar.app"
 

--- a/Casks/codexbar.rb
+++ b/Casks/codexbar.rb
@@ -8,7 +8,7 @@ cask "codexbar" do
   desc "Menu bar usage monitor for Codex and Claude"
   homepage "https://codexbar.app/"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "CodexBar.app"
   binary "#{appdir}/CodexBar.app/Contents/Helpers/CodexBarCLI", target: "codexbar"

--- a/Casks/repobar.rb
+++ b/Casks/repobar.rb
@@ -8,7 +8,7 @@ cask "repobar" do
   desc "Menu bar dashboard for GitHub repository health"
   homepage "https://repobar.app/"
 
-  depends_on macos: ">= :sequoia"
+  depends_on macos: :sequoia
 
   app "RepoBar.app"
   binary "#{appdir}/RepoBar.app/Contents/MacOS/repobarcli", target: "repobar"

--- a/Casks/trimmy.rb
+++ b/Casks/trimmy.rb
@@ -8,7 +8,7 @@ cask "trimmy" do
   homepage "https://github.com/steipete/Trimmy"
 
   depends_on arch: :arm64
-  depends_on macos: ">= :sequoia"
+  depends_on macos: :sequoia
 
   app "Trimmy.app"
 


### PR DESCRIPTION
## Summary

Homebrew deprecated the `">= :symbol"` string format for `depends_on macos:` in favor of the symbol form. This was emitting a warning on every install/upgrade:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated!
Use `depends_on macos: :sonoma` instead.
```

- `Casks/codexbar.rb`: `">= :sonoma"` → `:sonoma`
- `Casks/blackbar.rb`: `">= :sonoma"` → `:sonoma`
- `Casks/repobar.rb`: `">= :sequoia"` → `:sequoia`
- `Casks/trimmy.rb`: `">= :sequoia"` → `:sequoia`

No behavior change. Both forms enforce the same minimum macOS version requirement.

## Test plan

- [ ] `brew audit --cask Casks/codexbar.rb` passes without deprecation warning
- [ ] Same for blackbar, repobar, trimmy

🤖 Generated with [Claude Code](https://claude.com/claude-code)