### PR TITLE
Fix CodexBar macOS dependency syntax

### DIFF
--- a/Casks/codexbar.rb
+++ b/Casks/codexbar.rb
@@ -8,7 +8,7 @@ cask "codexbar" do
   desc "Menu bar usage monitor for Codex and Claude"
   homepage "https://codexbar.app/"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "CodexBar.app"
   binary "#{appdir}/CodexBar.app/Contents/Helpers/CodexBarCLI", target: "codexbar"


### PR DESCRIPTION
## Summary
- update CodexBar cask to use Homebrew's symbol format for macOS dependency
- resolves the deprecation warning for string comparison format in depends_on macos

## Validation
- ruby -c Casks/codexbar.rb
- git diff --check

Note: brew audit/style could not be completed locally because Homebrew attempted to use an unreachable local proxy at 127.0.0.1:7897 and write to the /opt Homebrew vendor bundle path.