### PR TITLE
fix: support universal macOS top-level formula updates

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -15,6 +15,7 @@ import os
 import pathlib
 import re
 import sys
+import urllib.parse
 import urllib.request
 
 
@@ -447,6 +448,53 @@ def update_top_level_url_and_sha(text: str, url: str, digest: str, version: str)
     )
 
 
+def release_artifact_name(url: str) -> str:
+    return pathlib.PurePosixPath(urllib.parse.urlparse(url).path).name
+
+
+def artifact_name_matches_target(
+    name: str,
+    target: str,
+    target_aliases: dict[str, str],
+    version: str,
+) -> bool:
+    version_suffix = rf'[-_.]v?{re.escape(version)}(?:$|[.])'
+    for marker in target_markers(target, target_aliases.get(target)):
+        pattern = rf'(?:^|[-_.]){re.escape(marker)}(?:$|[.]|{version_suffix})'
+        if re.search(pattern, name):
+            return True
+    return False
+
+
+def remove_top_level_arm64_dependency_for_universal_macos(
+    text: str,
+    macos_url: str,
+    target_aliases: dict[str, str],
+    version: str,
+) -> str:
+    if not artifact_name_matches_target(
+        release_artifact_name(macos_url),
+        "darwin_universal",
+        target_aliases,
+        version,
+    ):
+        return text
+
+    has_macos_dependency = re.search(
+        r'^  depends_on\s+(?::macos\b|(?:maximum_)?macos:)',
+        text,
+        flags=re.MULTILINE,
+    )
+    replacement = "" if has_macos_dependency else r"\g<indent>depends_on :macos\n"
+    return re.sub(
+        r'^(?P<indent>  )depends_on\s+arch:\s+:arm64\s*\n',
+        replacement,
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+
 def update_version(text: str, version: str) -> str:
     return replace_zero_or_one(
         text,
@@ -654,6 +702,7 @@ def main() -> int:
             text = update_url_and_sha_in_stanza(text, "on_linux", linux_url, linux_sha, version)
         else:
             text = update_top_level_url_and_sha(text, macos_url, macos_sha, version)
+            text = remove_top_level_arm64_dependency_for_universal_macos(text, macos_url, target_aliases, version)
             linux_sha = None
         print(f"macOS: {macos_sha}  {macos_url}")
         if linux_sha:

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import pathlib
+import sys
+import tempfile
 import unittest
+from unittest import mock
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -14,6 +18,26 @@ SPEC.loader.exec_module(update_formula)
 
 
 class UpdateFormulaTest(unittest.TestCase):
+    def run_main_in_temp_tap(self, formula_text: str, *args: str) -> str:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            formula_dir = root / "Formula"
+            formula_dir.mkdir()
+            formula_path = formula_dir / "sonoscli.rb"
+            formula_path.write_text(formula_text)
+
+            os.chdir(root)
+            try:
+                with (
+                    mock.patch.object(update_formula, "sha256", return_value="c" * 64),
+                    mock.patch.object(sys, "argv", ["update_formula.py", *args]),
+                ):
+                    update_formula.main()
+                return formula_path.read_text()
+            finally:
+                os.chdir(original_cwd)
+
     def test_updates_duplicate_source_url_checksums_in_stanza(self) -> None:
         text = '''class Camsnap < Formula
   version "0.2.0"
@@ -219,6 +243,350 @@ end
         self.assertIn('version "0.27.0"', updated)
         self.assertIn('sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"', updated)
         self.assertIn("CodexBar-macos-universal-#{version}.zip", updated)
+
+    def test_arm64_macos_artifact_keeps_top_level_arch_restriction(self) -> None:
+        text = '''class Sonoscli < Formula
+  desc "Control Sonos speakers from the command-line"
+  homepage "https://github.com/steipete/sonoscli"
+  url "https://github.com/steipete/sonoscli/releases/download/v0.3.1/sonoscli_0.3.1_darwin_arm64.tar.gz"
+  version "0.3.1"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  license "MIT"
+
+  depends_on arch: :arm64
+
+  def install
+    bin.install Dir["**/sonos"].first => "sonos"
+  end
+end
+'''
+
+        updated = self.run_main_in_temp_tap(
+            text,
+            "--formula",
+            "sonoscli",
+            "--tag",
+            "v0.3.2",
+            "--repository",
+            "steipete/sonoscli",
+            "--macos-artifact",
+            "sonoscli_0.3.2_darwin_arm64.tar.gz",
+        )
+
+        self.assertIn("sonoscli_0.3.2_darwin_arm64.tar.gz", updated)
+        self.assertIn('sha256 "' + "c" * 64 + '"', updated)
+        self.assertIn("depends_on arch: :arm64", updated)
+
+    def test_universal_macos_artifact_removes_top_level_arm64_restriction_idempotently(self) -> None:
+        text = '''class Sonoscli < Formula
+  desc "Control Sonos speakers from the command-line"
+  homepage "https://github.com/steipete/sonoscli"
+  url "https://github.com/steipete/sonoscli/releases/download/v0.3.1/sonoscli_0.3.1_darwin_arm64.tar.gz"
+  version "0.3.1"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  license "MIT"
+
+  depends_on arch: :arm64
+
+  def install
+    bin.install Dir["**/sonos"].first => "sonos"
+  end
+end
+'''
+
+        updated = self.run_main_in_temp_tap(
+            text,
+            "--formula",
+            "sonoscli",
+            "--tag",
+            "v0.3.2",
+            "--repository",
+            "steipete/sonoscli",
+            "--macos-artifact",
+            "sonoscli_0.3.2_macos-universal.tar.gz",
+        )
+        updated_again = update_formula.remove_top_level_arm64_dependency_for_universal_macos(
+            updated,
+            "https://github.com/steipete/sonoscli/releases/download/v0.3.2/sonoscli_0.3.2_macos-universal.tar.gz",
+            {},
+            "0.3.2",
+        )
+
+        self.assertIn("sonoscli_0.3.2_macos-universal.tar.gz", updated)
+        self.assertIn('version "0.3.2"', updated)
+        self.assertIn('sha256 "' + "c" * 64 + '"', updated)
+        self.assertNotIn("depends_on arch: :arm64", updated)
+        self.assertIn("depends_on :macos", updated)
+        self.assertEqual(updated_again, updated)
+
+    def test_universal_macos_artifact_leaves_other_arch_syntax_unchanged(self) -> None:
+        text = '''class Sonoscli < Formula
+  desc "Control Sonos speakers from the command-line"
+  homepage "https://github.com/steipete/sonoscli"
+  url "https://github.com/steipete/sonoscli/releases/download/v0.3.1/sonoscli_0.3.1_darwin_arm64.tar.gz"
+  version "0.3.1"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  license "MIT"
+
+  depends_on arch: :x86_64
+  depends_on "libusb"
+
+  def install
+    bin.install Dir["**/sonos"].first => "sonos"
+  end
+end
+'''
+
+        updated = self.run_main_in_temp_tap(
+            text,
+            "--formula",
+            "sonoscli",
+            "--tag",
+            "v0.3.2",
+            "--repository",
+            "steipete/sonoscli",
+            "--macos-artifact",
+            "sonoscli_0.3.2_macos-universal.tar.gz",
+        )
+
+        self.assertIn("depends_on arch: :x86_64", updated)
+        self.assertIn('depends_on "libusb"', updated)
+
+    def test_universal_repo_name_does_not_remove_arm64_restriction(self) -> None:
+        text = '''class Sonoscli < Formula
+  desc "Control Sonos speakers from the command-line"
+  homepage "https://github.com/steipete/macos-universal-tools"
+  url "https://github.com/steipete/macos-universal-tools/releases/download/v0.3.1/sonoscli_0.3.1_darwin_arm64.tar.gz"
+  version "0.3.1"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  license "MIT"
+
+  depends_on arch: :arm64
+
+  def install
+    bin.install Dir["**/sonos"].first => "sonos"
+  end
+end
+'''
+
+        updated = self.run_main_in_temp_tap(
+            text,
+            "--formula",
+            "sonoscli",
+            "--tag",
+            "v0.3.2",
+            "--repository",
+            "steipete/macos-universal-tools",
+            "--macos-artifact",
+            "sonoscli_0.3.2_darwin_arm64.tar.gz",
+        )
+
+        self.assertIn("sonoscli_0.3.2_darwin_arm64.tar.gz", updated)
+        self.assertIn("depends_on arch: :arm64", updated)
+
+    def test_universal_artifact_prefix_does_not_remove_arm64_restriction(self) -> None:
+        text = '''class Sonoscli < Formula
+  desc "Control Sonos speakers from the command-line"
+  homepage "https://github.com/steipete/sonoscli"
+  url "https://github.com/steipete/sonoscli/releases/download/v0.3.1/macos-universal-tools_0.3.1_darwin_arm64.tar.gz"
+  version "0.3.1"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  license "MIT"
+
+  depends_on arch: :arm64
+
+  def install
+    bin.install Dir["**/sonos"].first => "sonos"
+  end
+end
+'''
+
+        updated = self.run_main_in_temp_tap(
+            text,
+            "--formula",
+            "sonoscli",
+            "--tag",
+            "v0.3.2",
+            "--repository",
+            "steipete/sonoscli",
+            "--macos-artifact",
+            "macos-universal-tools_0.3.2_darwin_arm64.tar.gz",
+        )
+
+        self.assertIn("macos-universal-tools_0.3.2_darwin_arm64.tar.gz", updated)
+        self.assertIn("depends_on arch: :arm64", updated)
+
+    def test_existing_macos_dependency_is_not_duplicated(self) -> None:
+        text = '''class Sonoscli < Formula
+  desc "Control Sonos speakers from the command-line"
+  homepage "https://github.com/steipete/sonoscli"
+  url "https://github.com/steipete/sonoscli/releases/download/v0.3.1/sonoscli_0.3.1_darwin_arm64.tar.gz"
+  version "0.3.1"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  license "MIT"
+
+  depends_on :macos
+  depends_on arch: :arm64
+
+  def install
+    bin.install Dir["**/sonos"].first => "sonos"
+  end
+end
+'''
+
+        updated = self.run_main_in_temp_tap(
+            text,
+            "--formula",
+            "sonoscli",
+            "--tag",
+            "v0.3.2",
+            "--repository",
+            "steipete/sonoscli",
+            "--macos-artifact",
+            "sonoscli_0.3.2_macos-universal.tar.gz",
+        )
+
+        self.assertEqual(updated.count("depends_on :macos"), 1)
+        self.assertNotIn("depends_on arch: :arm64", updated)
+
+    def test_existing_versioned_macos_dependency_is_not_duplicated(self) -> None:
+        text = '''class Sonoscli < Formula
+  desc "Control Sonos speakers from the command-line"
+  homepage "https://github.com/steipete/sonoscli"
+  url "https://github.com/steipete/sonoscli/releases/download/v0.3.1/sonoscli_0.3.1_darwin_arm64.tar.gz"
+  version "0.3.1"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  license "MIT"
+
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  def install
+    bin.install Dir["**/sonos"].first => "sonos"
+  end
+end
+'''
+
+        updated = self.run_main_in_temp_tap(
+            text,
+            "--formula",
+            "sonoscli",
+            "--tag",
+            "v0.3.2",
+            "--repository",
+            "steipete/sonoscli",
+            "--macos-artifact",
+            "sonoscli_0.3.2_macos-universal.tar.gz",
+        )
+
+        self.assertIn("depends_on macos: :sonoma", updated)
+        self.assertNotIn("depends_on :macos", updated)
+        self.assertNotIn("depends_on arch: :arm64", updated)
+
+    def test_nested_macos_dependency_does_not_count_as_top_level(self) -> None:
+        text = '''class Sonoscli < Formula
+  desc "Control Sonos speakers from the command-line"
+  homepage "https://github.com/steipete/sonoscli"
+  url "https://github.com/steipete/sonoscli/releases/download/v0.3.1/sonoscli_0.3.1_darwin_arm64.tar.gz"
+  version "0.3.1"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  license "MIT"
+
+  depends_on arch: :arm64
+
+  on_arm do
+    depends_on macos: :sonoma
+  end
+
+  def install
+    bin.install Dir["**/sonos"].first => "sonos"
+  end
+end
+'''
+
+        updated = self.run_main_in_temp_tap(
+            text,
+            "--formula",
+            "sonoscli",
+            "--tag",
+            "v0.3.2",
+            "--repository",
+            "steipete/sonoscli",
+            "--macos-artifact",
+            "sonoscli_0.3.2_macos-universal.tar.gz",
+        )
+
+        self.assertIn("  depends_on :macos", updated)
+        self.assertIn("    depends_on macos: :sonoma", updated)
+        self.assertNotIn("depends_on arch: :arm64", updated)
+
+    def test_universal_target_alias_removes_arm64_restriction(self) -> None:
+        text = '''class Sonoscli < Formula
+  desc "Control Sonos speakers from the command-line"
+  homepage "https://github.com/steipete/sonoscli"
+  url "https://github.com/steipete/sonoscli/releases/download/v0.3.1/sonoscli_0.3.1_darwin_arm64.tar.gz"
+  version "0.3.1"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  license "MIT"
+
+  depends_on arch: :arm64
+
+  def install
+    bin.install Dir["**/sonos"].first => "sonos"
+  end
+end
+'''
+
+        updated = self.run_main_in_temp_tap(
+            text,
+            "--formula",
+            "sonoscli",
+            "--tag",
+            "v0.3.2",
+            "--repository",
+            "steipete/sonoscli",
+            "--macos-artifact",
+            "sonoscli_0.3.2_fat.tar.gz",
+            "--target-aliases",
+            "darwin_universal=fat",
+        )
+
+        self.assertIn("sonoscli_0.3.2_fat.tar.gz", updated)
+        self.assertNotIn("depends_on arch: :arm64", updated)
+        self.assertIn("depends_on :macos", updated)
+
+    def test_universal_artifact_with_unlisted_archive_extension_removes_arm64_restriction(self) -> None:
+        text = '''class Sonoscli < Formula
+  desc "Control Sonos speakers from the command-line"
+  homepage "https://github.com/steipete/sonoscli"
+  url "https://github.com/steipete/sonoscli/releases/download/v0.3.1/sonoscli_0.3.1_darwin_arm64.tar.gz"
+  version "0.3.1"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  license "MIT"
+
+  depends_on arch: :arm64
+
+  def install
+    bin.install Dir["**/sonos"].first => "sonos"
+  end
+end
+'''
+
+        updated = self.run_main_in_temp_tap(
+            text,
+            "--formula",
+            "sonoscli",
+            "--tag",
+            "v0.3.2",
+            "--repository",
+            "steipete/sonoscli",
+            "--macos-artifact",
+            "sonoscli_0.3.2_darwin_universal.tar.zst",
+        )
+
+        self.assertIn("sonoscli_0.3.2_darwin_universal.tar.zst", updated)
+        self.assertNotIn("depends_on arch: :arm64", updated)
+        self.assertIn("depends_on :macos", updated)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Support top-level macOS universal artifacts by updating URL/SHA and replacing `depends_on arch: :arm64` with a macOS platform guard.
- Preserve ARM-only artifact restrictions and existing macOS requirements.
- Add regression coverage for sonoscli ARM/universal dispatches, idempotence, aliases, marker collisions, archive extensions, and scoped dependency handling.

## Proof
- `python3 -m unittest discover -s tests`
- `python3 .github/scripts/update_formula.py --formula sonoscli --tag v0.3.1 --repository steipete/sonoscli --macos-artifact sonoscli_0.3.1_darwin_arm64.tar.gz` plus no `Formula/sonoscli.rb` diff
- `ruby -c Formula/sonoscli.rb`
- `brew style --formula steipete/tap/sonoscli`
- `brew audit --formula steipete/tap/sonoscli`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "python3 -m unittest discover -s tests"`
