### PR TITLE
blackbar: update cask for v0.2.3

### DIFF
--- a/Casks/blackbar.rb
+++ b/Casks/blackbar.rb
@@ -1,6 +1,6 @@
 cask "blackbar" do
-  version "0.2.1"
-  sha256 "d7c88d05d6e58a501310f3b7fd4ac67fb0a5f1ad4b7d28370b909bbc512833fc"
+  version "0.2.3"
+  sha256 "8e5d1bbde874b07907cb8c5e822f270b559fcdde9f57ef066cff1b1728a97a43"
 
   url "https://github.com/steipete/BlackBar/releases/download/v#{version}/BlackBar-#{version}.zip",
       verified: "github.com/steipete/BlackBar/"


### PR DESCRIPTION
## Summary
- Update BlackBar cask from 0.2.1 to 0.2.3.
- Use the canonical published release asset and verified SHA-256.

## Release Asset
- URL: `https://github.com/steipete/BlackBar/releases/download/v0.2.3/BlackBar-0.2.3.zip`
- SHA-256: `8e5d1bbde874b07907cb8c5e822f270b559fcdde9f57ef066cff1b1728a97a43`

## Proof
- Downloaded asset independently with `curl -L --fail` and verified `shasum -a 256`.
- `ruby -c Casks/blackbar.rb`
- `python3 -m unittest discover -s tests`
- `HOMEBREW_DEVELOPER=1 brew style --cask Casks/blackbar.rb`
- `HOMEBREW_DEVELOPER=1 brew install --cask --force ./Casks/blackbar.rb`
- `plutil -p /Applications/BlackBar.app/Contents/Info.plist` showed `CFBundleShortVersionString => 0.2.3`
- `codesign --verify --deep --strict --verbose=2 /Applications/BlackBar.app`
- `open -Ra BlackBar`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "git diff --check && ruby -c Casks/blackbar.rb && python3 -m unittest discover -s tests && HOMEBREW_DEVELOPER=1 brew style --cask Casks/blackbar.rb"`
