### PR TITLE
Add auto_updates to codexbar cask

### DIFF
--- a/Casks/codexbar.rb
+++ b/Casks/codexbar.rb
@@ -8,6 +8,7 @@ cask "codexbar" do
   desc "Menu bar usage monitor for Codex and Claude"
   homepage "https://codexbar.app/"
 
+  auto_updates true
   depends_on macos: :sonoma
 
   app "CodexBar.app"


### PR DESCRIPTION
## What

Add `auto_updates true` to the `codexbar` cask.

## Why

CodexBar bundles Sparkle and ships an appcast, so the app updates itself in place. Its `Info.plist` contains:

- `SUFeedURL = https://raw.githubusercontent.com/steipete/CodexBar/main/appcast.xml`
- `SUPublicEDKey = AGCY8w5vHirVfGGDGc8Szc5iuOqupZSh9pMj/Qs67XI=`
- `SUEnableAutomaticChecks = 1`
- `Sparkle.framework` under `Contents/Frameworks/`

Without `auto_updates true`, Homebrew treats the cask as fully brew-managed and replaces the entire `.app` bundle on every `brew upgrade`. Replacing the bundle re-triggers macOS Gatekeeper and resets TCC permission grants, so the user has to re-approve the app's permissions after each upgrade.

Declaring `auto_updates true`:

- lets Sparkle perform updates in place, preserving Gatekeeper trust and TCC permissions across versions
- lets users exclude the cask from `brew upgrade` via `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS=1`, deferring to the app's own updater
- correctly documents that the app self-updates

## Validation

`brew style` on the patched cask passes with no offenses:

```
$ brew style Casks/codexbar.rb

1 file inspected, no offenses detected
```

(`brew audit Casks/codexbar.rb` is not usable here — current Homebrew rejects a path argument with `Calling 'brew audit [path ...]' is disabled! Use 'brew audit [name ...]' instead`, so `brew style` is the applicable check for this metadata-only change.)
