### PR TITLE
fix: harden formula update retries

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -15,25 +15,51 @@ import os
 import pathlib
 import re
 import sys
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 
 
 USER_AGENT = "steipete-homebrew-tap-updater"
+RELEASE_ASSET_ATTEMPTS = 6
+RELEASE_ASSET_INITIAL_BACKOFF = 10.0
 
 
-def sha256(url: str) -> str:
+def sha256(
+    url: str,
+    *,
+    attempts: int = RELEASE_ASSET_ATTEMPTS,
+    initial_backoff: float = RELEASE_ASSET_INITIAL_BACKOFF,
+) -> str:
     headers = {"User-Agent": USER_AGENT}
     token = os.environ.get("GITHUB_TOKEN")
     if token and url.startswith("https://github.com/"):
         headers["Authorization"] = f"Bearer {token}"
 
     request = urllib.request.Request(url, headers=headers)
-    digest = hashlib.sha256()
-    with urllib.request.urlopen(request) as response:
-        while chunk := response.read(1024 * 1024):
-            digest.update(chunk)
-    return digest.hexdigest()
+    for attempt in range(1, attempts + 1):
+        try:
+            digest = hashlib.sha256()
+            with urllib.request.urlopen(request) as response:
+                while chunk := response.read(1024 * 1024):
+                    digest.update(chunk)
+            return digest.hexdigest()
+        except urllib.error.HTTPError as error:
+            is_missing_release_asset = error.code == 404 and "/releases/download/" in url
+            if not is_missing_release_asset or attempt == attempts:
+                raise
+
+            error.close()
+            delay = initial_backoff * (2 ** (attempt - 1))
+            print(
+                f"release asset unavailable (404); retrying in {delay:g}s "
+                f"({attempt}/{attempts}): {url}",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+
+    raise AssertionError("unreachable")
 
 
 def replace_once(text: str, pattern: str, replacement: str, description: str) -> str:

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -133,4 +133,18 @@ jobs:
           else
             git commit -m "${FORMULA}: update formula for ${TAG}"
           fi
-          git push
+          for attempt in {1..5}; do
+            if git push; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 5 ]; then
+              echo "Push failed after $attempt attempts" >&2
+              exit 1
+            fi
+
+            echo "Push raced with main; fetching and rebasing before retry $((attempt + 1))/5" >&2
+            git fetch origin main
+            git rebase origin/main
+            sleep $((attempt * 5))
+          done

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Run the `Update Formula` workflow with:
 
 The workflow updates regular single-URL formulae, formulae with separate `on_macos` and `on_linux` stanzas, duplicate source-build URLs inside a stanza, and target-specific binary formulae when `artifact_template` is provided. Formulae with unsupported custom platform layouts still need manual updates.
 
+New release assets may briefly return 404 while publishing; the updater waits with exponential backoff. Concurrent formula updates rebase onto the latest `main` before retrying their push.
+
 OpenClaw-owned formulae live in `openclaw/tap`; migrated names are listed in `tap_migrations.json`.
 
 ## Update / Uninstall

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -6,6 +6,7 @@ import pathlib
 import sys
 import tempfile
 import unittest
+import urllib.error
 from unittest import mock
 
 
@@ -37,6 +38,47 @@ class UpdateFormulaTest(unittest.TestCase):
                 return formula_path.read_text()
             finally:
                 os.chdir(original_cwd)
+
+    def test_sha256_retries_missing_release_asset_with_backoff(self) -> None:
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.side_effect = [b"artifact", b""]
+        missing = urllib.error.HTTPError(
+            "https://github.com/openclaw/Peekaboo/releases/download/v1.0.0/peekaboo.tar.gz",
+            404,
+            "Not Found",
+            {},
+            None,
+        )
+
+        with (
+            mock.patch.object(update_formula.urllib.request, "urlopen", side_effect=[missing, response]),
+            mock.patch.object(update_formula.time, "sleep") as sleep,
+        ):
+            digest = update_formula.sha256(missing.url, attempts=2, initial_backoff=3)
+
+        self.assertEqual(digest, "c7c5c1d70c5dec4416ab6158afd0b223ef40c29b1dc1f97ed9428b94d4cadb1c")
+        sleep.assert_called_once_with(3)
+
+    def test_sha256_does_not_retry_non_release_404(self) -> None:
+        missing = urllib.error.HTTPError(
+            "https://github.com/openclaw/Peekaboo/archive/refs/tags/v1.0.0.tar.gz",
+            404,
+            "Not Found",
+            {},
+            None,
+        )
+
+        try:
+            with (
+                mock.patch.object(update_formula.urllib.request, "urlopen", side_effect=missing),
+                mock.patch.object(update_formula.time, "sleep") as sleep,
+                self.assertRaises(urllib.error.HTTPError),
+            ):
+                update_formula.sha256(missing.url, attempts=2, initial_backoff=3)
+        finally:
+            missing.close()
+
+        sleep.assert_not_called()
 
     def test_updates_duplicate_source_url_checksums_in_stanza(self) -> None:
         text = '''class Camsnap < Formula


### PR DESCRIPTION
## Summary

- retry transient 404s from GitHub release assets with bounded exponential backoff
- fetch and rebase before retrying formula-update pushes that race with concurrent main updates
- document the resilience behavior and cover checksum retry semantics with unit tests

## Proof

- `python3 -W error::ResourceWarning -m unittest discover -s tests -q` (18 tests)
- `python3 -m py_compile .github/scripts/update_formula.py`
- `git diff --check`
- AutoReview: clean, no accepted/actionable findings

## Failure evidence

- Peekaboo asset 404: https://github.com/steipete/homebrew-tap/actions/runs/29440392467
- Spogo concurrent-main race: https://github.com/steipete/homebrew-tap/actions/runs/29596800889
