### PR TITLE
feat: publish cask API metadata for mise bootstrap

### DIFF
--- a/.github/scripts/generate_cask_api.py
+++ b/.github/scripts/generate_cask_api.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Generate raw Homebrew API metadata for every cask in this tap."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9+._@-]*")
+LOCAL_STATE_DEFAULTS = {
+    "installed": None,
+    "installed_time": None,
+    "bundle_version": None,
+    "bundle_short_version": None,
+    "pinned": False,
+    "pinned_version": None,
+    "outdated": False,
+}
+
+
+def git_head(root: pathlib.Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def brew_metadata(tap: str, token: str) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
+    env["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
+    result = subprocess.run(
+        [
+            "brew",
+            "info",
+            "--json=v2",
+            "--variations",
+            "--cask",
+            f"{tap}/{token}",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"brew returned invalid JSON for {token}: {error}") from error
+
+    casks = payload.get("casks")
+    if not isinstance(casks, list) or len(casks) != 1 or not isinstance(casks[0], dict):
+        raise SystemExit(f"brew returned {len(casks) if isinstance(casks, list) else 0} casks for {token}")
+
+    metadata = casks[0]
+    for field, value in LOCAL_STATE_DEFAULTS.items():
+        metadata[field] = value
+    return metadata
+
+
+def validate_metadata(
+    metadata: dict[str, Any],
+    *,
+    tap: str,
+    token: str,
+    cask_path: pathlib.Path,
+    root: pathlib.Path,
+    source_head: str,
+) -> None:
+    expected_full_token = f"{tap}/{token}"
+    expected_source_path = cask_path.relative_to(root).as_posix()
+    expected_checksum = hashlib.sha256(cask_path.read_bytes()).hexdigest()
+    checks = {
+        "token": token,
+        "full_token": expected_full_token,
+        "tap": tap,
+        "tap_git_head": source_head,
+        "ruby_source_path": expected_source_path,
+    }
+    for field, expected in checks.items():
+        if metadata.get(field) != expected:
+            raise SystemExit(
+                f"{token}: {field} is {metadata.get(field)!r}, expected {expected!r}; "
+                "sync the tapped checkout to this commit before generating"
+            )
+
+    required_values = {
+        "version": metadata.get("version"),
+        "url": metadata.get("url"),
+        "sha256": metadata.get("sha256"),
+    }
+    for field, value in required_values.items():
+        if not isinstance(value, str) or not value:
+            raise SystemExit(f"{token}: brew metadata has no usable {field}")
+    artifacts = metadata.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        raise SystemExit(f"{token}: brew metadata has no artifacts")
+
+    checksum = metadata.get("ruby_source_checksum")
+    if not isinstance(checksum, dict) or checksum.get("sha256") != expected_checksum:
+        raise SystemExit(
+            f"{token}: ruby_source_checksum does not match {expected_source_path}; "
+            "sync the tapped checkout to this commit before generating"
+        )
+
+
+def generate(
+    *,
+    root: pathlib.Path = ROOT,
+    tap: str = "steipete/tap",
+    metadata_reader: Callable[[str, str], dict[str, Any]] = brew_metadata,
+    source_head: str | None = None,
+) -> list[pathlib.Path]:
+    casks_dir = root / "Casks"
+    output_dir = root / "api" / "cask"
+    cask_paths = sorted(casks_dir.glob("*.rb"))
+    if not cask_paths:
+        raise SystemExit(f"no casks found in {casks_dir}")
+
+    head = source_head or git_head(root)
+    generated: dict[pathlib.Path, str] = {}
+    for cask_path in cask_paths:
+        token = cask_path.stem
+        if not TOKEN_PATTERN.fullmatch(token):
+            raise SystemExit(f"unsupported cask token derived from {cask_path.name}: {token!r}")
+        metadata = metadata_reader(tap, token)
+        validate_metadata(
+            metadata,
+            tap=tap,
+            token=token,
+            cask_path=cask_path,
+            root=root,
+            source_head=head,
+        )
+        generated[output_dir / f"{token}.json"] = json.dumps(
+            metadata,
+            indent=2,
+            sort_keys=True,
+        ) + "\n"
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    expected_paths = set(generated)
+    for stale_path in output_dir.glob("*.json"):
+        if stale_path not in expected_paths:
+            stale_path.unlink()
+            print(f"removed stale {stale_path.relative_to(root)}")
+
+    for output_path, content in generated.items():
+        output_path.write_text(content)
+        print(f"generated {output_path.relative_to(root)}")
+    return sorted(expected_paths)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tap", default="steipete/tap", help="fully qualified tap name")
+    args = parser.parse_args()
+    try:
+        generate(tap=args.tap)
+    except subprocess.CalledProcessError as error:
+        if error.stderr:
+            print(error.stderr.rstrip(), file=sys.stderr)
+        raise SystemExit(f"command failed with exit code {error.returncode}: {' '.join(error.cmd)}") from error
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update-cask-api.yml
+++ b/.github/workflows/update-cask-api.yml
@@ -1,0 +1,87 @@
+name: Update Cask API Metadata
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "Casks/**"
+  workflow_run:
+    workflows:
+      - Update Formula
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-cask-api
+  cancel-in-progress: false
+
+jobs:
+  update-cask-api:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: macos-latest
+    steps:
+      - name: Checkout tap repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Setup Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Tap checked-out source
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          if brew tap | grep -qx "steipete/tap"; then
+            tap_repo="$(brew --repo steipete/tap)"
+            git -C "$tap_repo" fetch "$GITHUB_WORKSPACE" HEAD
+            git -C "$tap_repo" checkout --detach FETCH_HEAD
+          else
+            brew tap --custom-remote steipete/tap "$GITHUB_WORKSPACE"
+          fi
+
+      - name: Generate cask API metadata
+        run: python3 .github/scripts/generate_cask_api.py
+
+      - name: Commit and push
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          git add api/cask
+          if git diff --cached --quiet; then
+            echo "Cask API metadata already up to date"
+            exit 0
+          fi
+
+          git commit -m "chore: update cask API metadata"
+          for attempt in {1..5}; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 5 ]; then
+              echo "Push failed after $attempt attempts" >&2
+              exit 1
+            fi
+
+            echo "Push raced with main; rebasing and regenerating before retry $((attempt + 1))/5" >&2
+            git fetch origin main
+            git rebase origin/main
+
+            tap_repo="$(brew --repo steipete/tap)"
+            git -C "$tap_repo" fetch "$GITHUB_WORKSPACE" HEAD
+            git -C "$tap_repo" checkout --detach FETCH_HEAD
+            python3 .github/scripts/generate_cask_api.py
+            git add api/cask
+            if ! git diff --cached --quiet; then
+              git commit -m "chore: refresh cask API metadata after push race"
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ When `assets` is present, the updater uses each filename and checksum verbatim, 
 
 New release assets may briefly return 404 while publishing; the updater waits with exponential backoff. Concurrent formula updates rebase onto the latest `main` before retrying their push.
 
+## Cask API Metadata
+
+Raw metadata for API-based consumers such as mise is published at `api/cask/<token>.json`. The `Update Cask API Metadata` workflow regenerates every cask after direct cask changes and after the release updater completes, including casks changed by that workflow's GitHub token.
+
+To regenerate locally, first make sure `steipete/tap` is tapped at the same commit as this checkout, then run:
+
+```bash
+python3 .github/scripts/generate_cask_api.py
+```
+
 OpenClaw-owned formulae live in `openclaw/tap`; migrated names are listed in `tap_migrations.json`.
 
 ## Update / Uninstall

--- a/api/cask/blackbar.json
+++ b/api/cask/blackbar.json
@@ -1,0 +1,82 @@
+{
+  "artifacts": [
+    {
+      "app": [
+        "BlackBar.app"
+      ],
+      "target": "/Applications/BlackBar.app"
+    },
+    {
+      "zap": [
+        {
+          "trash": [
+            "~/Library/Application Support/BlackBar",
+            "~/Library/Application Support/com.steipete.blackbar",
+            "~/Library/Caches/BlackBar",
+            "~/Library/Caches/com.steipete.blackbar",
+            "~/Library/HTTPStorages/com.steipete.blackbar",
+            "~/Library/Preferences/com.steipete.blackbar.plist",
+            "~/Library/Saved Application State/com.steipete.blackbar.savedState"
+          ]
+        }
+      ]
+    }
+  ],
+  "auto_updates": true,
+  "autobump": true,
+  "bundle_short_version": null,
+  "bundle_version": null,
+  "caveats": null,
+  "caveats_rosetta": null,
+  "conflicts_with": null,
+  "container": null,
+  "depends_on": {
+    "macos": {
+      ">=": [
+        "14"
+      ]
+    }
+  },
+  "deprecate_args": null,
+  "deprecated": false,
+  "deprecation_date": null,
+  "deprecation_reason": null,
+  "deprecation_replacement_cask": null,
+  "deprecation_replacement_formula": null,
+  "desc": "Menu bar app for Blacksmith CI status and live vCPU usage",
+  "disable_args": null,
+  "disable_date": null,
+  "disable_reason": null,
+  "disable_replacement_cask": null,
+  "disable_replacement_formula": null,
+  "disabled": false,
+  "full_token": "steipete/tap/blackbar",
+  "homepage": "https://black.bar/",
+  "installed": null,
+  "installed_time": null,
+  "languages": [],
+  "name": [
+    "BlackBar"
+  ],
+  "no_autobump_message": null,
+  "old_tokens": [],
+  "outdated": false,
+  "pinned": false,
+  "pinned_version": null,
+  "rename": [],
+  "ruby_source_checksum": {
+    "sha256": "ee74455cc44d4a507411e49a853132d5064fa869757ed0e90f026af97602e625"
+  },
+  "ruby_source_path": "Casks/blackbar.rb",
+  "sha256": "068ff4ceb559a357f142b693fca2ffbc05057f5b9a2f634eb35693c252e4b5bc",
+  "skip_livecheck": false,
+  "tap": "steipete/tap",
+  "tap_git_head": "5bfaad78863f58414e59d97249a4508185f0a543",
+  "token": "blackbar",
+  "url": "https://github.com/steipete/BlackBar/releases/download/v0.2.5/BlackBar-0.2.5.zip",
+  "url_specs": {
+    "verified": "github.com/steipete/BlackBar/"
+  },
+  "variations": {},
+  "version": "0.2.5"
+}

--- a/api/cask/codexbar.json
+++ b/api/cask/codexbar.json
@@ -1,0 +1,98 @@
+{
+  "artifacts": [
+    {
+      "app": [
+        "CodexBar.app"
+      ],
+      "target": "/Applications/CodexBar.app"
+    },
+    {
+      "binary": [
+        "/Applications/CodexBar.app/Contents/Helpers/CodexBarCLI",
+        {
+          "target": "codexbar"
+        }
+      ],
+      "target": "/opt/homebrew/bin/codexbar"
+    },
+    {
+      "zap": [
+        {
+          "trash": [
+            "~/Library/Application Scripts/com.steipete.codexbar",
+            "~/Library/Application Scripts/com.steipete.codexbar.widget",
+            "~/Library/Application Support/CodexBar",
+            "~/Library/Application Support/com.steipete.codexbar",
+            "~/Library/Caches/CodexBar",
+            "~/Library/Caches/com.steipete.codexbar",
+            "~/Library/Containers/com.steipete.codexbar",
+            "~/Library/Containers/com.steipete.codexbar.widget",
+            "~/Library/Group Containers/group.com.steipete.codexbar",
+            "~/Library/HTTPStorages/com.steipete.codexbar",
+            "~/Library/HTTPStorages/com.steipete.codexbar.binarycookies",
+            "~/Library/Preferences/com.steipete.codexbar.plist",
+            "~/Library/Saved Application State/com.steipete.codexbar.savedState",
+            "~/Library/WebKit/com.steipete.codexbar"
+          ]
+        }
+      ]
+    }
+  ],
+  "auto_updates": true,
+  "autobump": true,
+  "bundle_short_version": null,
+  "bundle_version": null,
+  "caveats": null,
+  "caveats_rosetta": null,
+  "conflicts_with": null,
+  "container": null,
+  "depends_on": {
+    "macos": {
+      ">=": [
+        "14"
+      ]
+    }
+  },
+  "deprecate_args": null,
+  "deprecated": false,
+  "deprecation_date": null,
+  "deprecation_reason": null,
+  "deprecation_replacement_cask": null,
+  "deprecation_replacement_formula": null,
+  "desc": "Menu bar usage monitor for Codex and Claude",
+  "disable_args": null,
+  "disable_date": null,
+  "disable_reason": null,
+  "disable_replacement_cask": null,
+  "disable_replacement_formula": null,
+  "disabled": false,
+  "full_token": "steipete/tap/codexbar",
+  "homepage": "https://codexbar.app/",
+  "installed": null,
+  "installed_time": null,
+  "languages": [],
+  "name": [
+    "CodexBar"
+  ],
+  "no_autobump_message": null,
+  "old_tokens": [],
+  "outdated": false,
+  "pinned": false,
+  "pinned_version": null,
+  "rename": [],
+  "ruby_source_checksum": {
+    "sha256": "9045e2127dbb2669ab5e84a74c9e4746b287fbe73b9cf161905b2f355991a7e5"
+  },
+  "ruby_source_path": "Casks/codexbar.rb",
+  "sha256": "972b1f300b1265c175e9c6f6c5b7183063217a97f0a5fcc1f5d3ef06a526064f",
+  "skip_livecheck": false,
+  "tap": "steipete/tap",
+  "tap_git_head": "5bfaad78863f58414e59d97249a4508185f0a543",
+  "token": "codexbar",
+  "url": "https://github.com/steipete/CodexBar/releases/download/v0.49.0/CodexBar-macos-universal-0.49.0.zip",
+  "url_specs": {
+    "verified": "github.com/steipete/CodexBar/"
+  },
+  "variations": {},
+  "version": "0.49.0"
+}

--- a/api/cask/nameplate.json
+++ b/api/cask/nameplate.json
@@ -1,0 +1,91 @@
+{
+  "artifacts": [
+    {
+      "app": [
+        "Nameplate.app"
+      ],
+      "target": "/Applications/Nameplate.app"
+    },
+    {
+      "binary": [
+        "/Applications/Nameplate.app/Contents/Helpers/nameplate"
+      ],
+      "target": "/opt/homebrew/bin/nameplate"
+    },
+    {
+      "zap": [
+        {
+          "trash": [
+            "~/Library/Caches/com.steipete.nameplate",
+            "~/Library/HTTPStorages/com.steipete.nameplate",
+            "~/Library/Preferences/com.steipete.nameplate.plist",
+            "~/Library/Saved Application State/com.steipete.nameplate.savedState"
+          ]
+        }
+      ]
+    }
+  ],
+  "auto_updates": null,
+  "autobump": true,
+  "bundle_short_version": null,
+  "bundle_version": null,
+  "caveats": null,
+  "caveats_rosetta": null,
+  "conflicts_with": null,
+  "container": null,
+  "depends_on": {
+    "arch": [
+      {
+        "bits": 64,
+        "type": "arm"
+      }
+    ],
+    "macos": {
+      ">=": [
+        "15"
+      ]
+    }
+  },
+  "deprecate_args": null,
+  "deprecated": false,
+  "deprecation_date": null,
+  "deprecation_reason": null,
+  "deprecation_replacement_cask": null,
+  "deprecation_replacement_formula": null,
+  "desc": "Brand every computer in your fleet with click-through identity overlays",
+  "disable_args": null,
+  "disable_date": null,
+  "disable_reason": null,
+  "disable_replacement_cask": null,
+  "disable_replacement_formula": null,
+  "disabled": false,
+  "full_token": "steipete/tap/nameplate",
+  "homepage": "https://nameplate.sh/",
+  "installed": null,
+  "installed_time": null,
+  "languages": [],
+  "name": [
+    "Nameplate"
+  ],
+  "no_autobump_message": null,
+  "old_tokens": [],
+  "outdated": false,
+  "pinned": false,
+  "pinned_version": null,
+  "rename": [],
+  "ruby_source_checksum": {
+    "sha256": "ed314577dc171fd4d2790832d136e157a0f60bb0e53ac534763bbf15bc6aa720"
+  },
+  "ruby_source_path": "Casks/nameplate.rb",
+  "sha256": "639e9eff1fc3e57a351a9cae4dc31eea5b3d6b730b5e21609eeebf48350f936f",
+  "skip_livecheck": false,
+  "tap": "steipete/tap",
+  "tap_git_head": "5bfaad78863f58414e59d97249a4508185f0a543",
+  "token": "nameplate",
+  "url": "https://github.com/steipete/Nameplate/releases/download/v0.3.1/Nameplate-0.3.1.zip",
+  "url_specs": {
+    "verified": "github.com/steipete/Nameplate/"
+  },
+  "variations": {},
+  "version": "0.3.1"
+}

--- a/api/cask/repobar.json
+++ b/api/cask/repobar.json
@@ -1,0 +1,91 @@
+{
+  "artifacts": [
+    {
+      "app": [
+        "RepoBar.app"
+      ],
+      "target": "/Applications/RepoBar.app"
+    },
+    {
+      "binary": [
+        "/Applications/RepoBar.app/Contents/MacOS/repobarcli",
+        {
+          "target": "repobar"
+        }
+      ],
+      "target": "/opt/homebrew/bin/repobar"
+    },
+    {
+      "zap": [
+        {
+          "trash": [
+            "~/Library/Application Support/com.steipete.repobar",
+            "~/Library/Application Support/RepoBar",
+            "~/Library/Caches/com.steipete.repobar",
+            "~/Library/Caches/RepoBar",
+            "~/Library/HTTPStorages/com.steipete.repobar",
+            "~/Library/Preferences/com.steipete.repobar.plist",
+            "~/Library/Saved Application State/com.steipete.repobar.savedState"
+          ]
+        }
+      ]
+    }
+  ],
+  "auto_updates": null,
+  "autobump": true,
+  "bundle_short_version": null,
+  "bundle_version": null,
+  "caveats": null,
+  "caveats_rosetta": null,
+  "conflicts_with": null,
+  "container": null,
+  "depends_on": {
+    "macos": {
+      ">=": [
+        "15"
+      ]
+    }
+  },
+  "deprecate_args": null,
+  "deprecated": false,
+  "deprecation_date": null,
+  "deprecation_reason": null,
+  "deprecation_replacement_cask": null,
+  "deprecation_replacement_formula": null,
+  "desc": "Menu bar dashboard for GitHub repository health",
+  "disable_args": null,
+  "disable_date": null,
+  "disable_reason": null,
+  "disable_replacement_cask": null,
+  "disable_replacement_formula": null,
+  "disabled": false,
+  "full_token": "steipete/tap/repobar",
+  "homepage": "https://repobar.app/",
+  "installed": null,
+  "installed_time": null,
+  "languages": [],
+  "name": [
+    "RepoBar"
+  ],
+  "no_autobump_message": null,
+  "old_tokens": [],
+  "outdated": false,
+  "pinned": false,
+  "pinned_version": null,
+  "rename": [],
+  "ruby_source_checksum": {
+    "sha256": "9aeb8e68199fb1e40349ac7490dc59376a9d64b647dbc1f8445b26b25ff20f22"
+  },
+  "ruby_source_path": "Casks/repobar.rb",
+  "sha256": "5f7401ee36f4d1048548204fb540562ccb6d4101b3da109c1fc6914095c855e8",
+  "skip_livecheck": false,
+  "tap": "steipete/tap",
+  "tap_git_head": "5bfaad78863f58414e59d97249a4508185f0a543",
+  "token": "repobar",
+  "url": "https://github.com/steipete/RepoBar/releases/download/v0.8.3/RepoBar-0.8.3.zip",
+  "url_specs": {
+    "verified": "github.com/steipete/RepoBar/"
+  },
+  "variations": {},
+  "version": "0.8.3"
+}

--- a/api/cask/trimmy.json
+++ b/api/cask/trimmy.json
@@ -1,0 +1,88 @@
+{
+  "artifacts": [
+    {
+      "app": [
+        "Trimmy.app"
+      ],
+      "target": "/Applications/Trimmy.app"
+    },
+    {
+      "zap": [
+        {
+          "trash": [
+            "~/Library/Application Scripts/com.steipete.trimmy",
+            "~/Library/Application Support/Trimmy",
+            "~/Library/Caches/com.steipete.trimmy",
+            "~/Library/Containers/com.steipete.trimmy",
+            "~/Library/HTTPStorages/com.steipete.trimmy",
+            "~/Library/HTTPStorages/com.steipete.trimmy.binarycookies",
+            "~/Library/Preferences/com.steipete.trimmy.plist",
+            "~/Library/Saved Application State/com.steipete.trimmy.savedState",
+            "~/Library/WebKit/com.steipete.trimmy"
+          ]
+        }
+      ]
+    }
+  ],
+  "auto_updates": null,
+  "autobump": true,
+  "bundle_short_version": null,
+  "bundle_version": null,
+  "caveats": null,
+  "caveats_rosetta": null,
+  "conflicts_with": null,
+  "container": null,
+  "depends_on": {
+    "arch": [
+      {
+        "bits": 64,
+        "type": "arm"
+      }
+    ],
+    "macos": {
+      ">=": [
+        "15"
+      ]
+    }
+  },
+  "deprecate_args": null,
+  "deprecated": false,
+  "deprecation_date": null,
+  "deprecation_reason": null,
+  "deprecation_replacement_cask": null,
+  "deprecation_replacement_formula": null,
+  "desc": "Paste-once, run-once clipboard cleaner for terminal snippets",
+  "disable_args": null,
+  "disable_date": null,
+  "disable_reason": null,
+  "disable_replacement_cask": null,
+  "disable_replacement_formula": null,
+  "disabled": false,
+  "full_token": "steipete/tap/trimmy",
+  "homepage": "https://github.com/steipete/Trimmy",
+  "installed": null,
+  "installed_time": null,
+  "languages": [],
+  "name": [
+    "Trimmy"
+  ],
+  "no_autobump_message": null,
+  "old_tokens": [],
+  "outdated": false,
+  "pinned": false,
+  "pinned_version": null,
+  "rename": [],
+  "ruby_source_checksum": {
+    "sha256": "51c2db57281e2fd56d116bcdd12c23ae569f55b93d5d691b5d1b6fd88828c855"
+  },
+  "ruby_source_path": "Casks/trimmy.rb",
+  "sha256": "d9692230463ec0a5fe7138875e451b923645184ada1dab3983ae1ec852b63c2e",
+  "skip_livecheck": false,
+  "tap": "steipete/tap",
+  "tap_git_head": "5bfaad78863f58414e59d97249a4508185f0a543",
+  "token": "trimmy",
+  "url": "https://github.com/steipete/Trimmy/releases/download/v0.10.1/Trimmy-0.10.1.zip",
+  "url_specs": {},
+  "variations": {},
+  "version": "0.10.1"
+}

--- a/tests/test_generate_cask_api.py
+++ b/tests/test_generate_cask_api.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / ".github" / "scripts" / "generate_cask_api.py"
+SPEC = importlib.util.spec_from_file_location("generate_cask_api", SCRIPT)
+assert SPEC and SPEC.loader
+generate_cask_api = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(generate_cask_api)
+
+
+class GenerateCaskApiTest(unittest.TestCase):
+    def metadata(self, tap: str, token: str, cask_path: pathlib.Path, head: str) -> dict[str, object]:
+        return {
+            "token": token,
+            "full_token": f"{tap}/{token}",
+            "tap": tap,
+            "version": "1.2.3",
+            "url": f"https://example.test/{token}.zip",
+            "sha256": "a" * 64,
+            "artifacts": [{"app": [f"{token}.app"]}],
+            "tap_git_head": head,
+            "ruby_source_path": f"Casks/{token}.rb",
+            "ruby_source_checksum": {
+                "sha256": hashlib.sha256(cask_path.read_bytes()).hexdigest(),
+            },
+        }
+
+    def test_generates_every_cask_and_removes_stale_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            casks_dir = root / "Casks"
+            output_dir = root / "api" / "cask"
+            casks_dir.mkdir()
+            output_dir.mkdir(parents=True)
+            for token in ("alpha", "beta"):
+                (casks_dir / f"{token}.rb").write_text(f'cask "{token}" do\nend\n')
+            stale_path = output_dir / "removed.json"
+            stale_path.write_text("{}\n")
+
+            head = "1" * 40
+
+            def read_metadata(tap: str, token: str) -> dict[str, object]:
+                return self.metadata(tap, token, casks_dir / f"{token}.rb", head)
+
+            paths = generate_cask_api.generate(
+                root=root,
+                metadata_reader=read_metadata,
+                source_head=head,
+            )
+
+            self.assertEqual([path.name for path in paths], ["alpha.json", "beta.json"])
+            self.assertFalse(stale_path.exists())
+            for token in ("alpha", "beta"):
+                payload = json.loads((output_dir / f"{token}.json").read_text())
+                self.assertEqual(payload["token"], token)
+                self.assertEqual(payload["full_token"], f"steipete/tap/{token}")
+
+    def test_rejects_metadata_from_a_stale_tap_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            casks_dir = root / "Casks"
+            casks_dir.mkdir()
+            cask_path = casks_dir / "alpha.rb"
+            cask_path.write_text('cask "alpha" do\nend\n')
+            metadata = self.metadata("steipete/tap", "alpha", cask_path, "a" * 40)
+
+            with self.assertRaisesRegex(SystemExit, "sync the tapped checkout"):
+                generate_cask_api.generate(
+                    root=root,
+                    metadata_reader=lambda _tap, _token: metadata,
+                    source_head="b" * 40,
+                )
+
+    def test_local_state_defaults_match_static_api_behavior(self) -> None:
+        self.assertEqual(
+            generate_cask_api.LOCAL_STATE_DEFAULTS,
+            {
+                "installed": None,
+                "installed_time": None,
+                "bundle_version": None,
+                "bundle_short_version": None,
+                "pinned": False,
+                "pinned_version": None,
+                "outdated": False,
+            },
+        )
+
+    def test_brew_metadata_normalizes_machine_local_state(self) -> None:
+        payload = self.metadata(
+            "steipete/tap",
+            "alpha",
+            pathlib.Path(__file__),
+            "1" * 40,
+        )
+        payload.update(
+            {
+                "installed": "1.2.3",
+                "installed_time": 123,
+                "bundle_version": "42",
+                "bundle_short_version": "1.2.3",
+                "pinned": True,
+                "pinned_version": "1.2.3",
+                "outdated": True,
+            }
+        )
+        completed = mock.Mock(stdout=json.dumps({"casks": [payload]}))
+
+        with mock.patch.object(generate_cask_api.subprocess, "run", return_value=completed) as run:
+            metadata = generate_cask_api.brew_metadata("steipete/tap", "alpha")
+
+        for field, expected in generate_cask_api.LOCAL_STATE_DEFAULTS.items():
+            self.assertEqual(metadata[field], expected)
+        command = run.call_args.args[0]
+        self.assertEqual(command[-1], "steipete/tap/alpha")
+        self.assertEqual(run.call_args.kwargs["env"]["HOMEBREW_NO_INSTALL_FROM_API"], "1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #53.

`mise` bootstraps third-party casks by reading Homebrew API metadata at
`api/cask/<token>.json`, which this tap never published — so
`brew-cask:steipete/tap/codexbar` could not resolve. Confirmed against real
mise before the change:

```
mise ERROR failed to fetch Homebrew cask 'steipete/tap/codexbar' directly
mise ERROR HTTP status client error (404 Not Found) for url
(https://raw.githubusercontent.com/steipete/homebrew-tap/HEAD/api/cask/codexbar.json)
```

Per @mkaput's preference this generates metadata for **every** cask rather than
a handwritten CodexBar-only file. Five artifacts are published: blackbar,
codexbar, nameplate, repobar, trimmy.

The staleness problem is handled deliberately, because we already got bitten by
a formula going stale on the other tap. Regeneration is triggered both by direct
cask changes and by successful `Update Formula` runs — the latter matters
because those push with a GitHub token, and token pushes do not emit another
workflow event. Runs are serialized and regenerate on push races.

Generated fields cover everything mise's current `Cask` structure deserializes.
Validation ties each artifact back to its source:

```
cask version=0.49.0   json version=0.49.0
cask sha256=972b1f...6064f
json sha256=972b1f...6064f
source checksum=9045e2...a7e5
metadata checksum=9045e2...a7e5
```

Source-blind validation passed 5/5 on required fields, confirmed the expected
release for codexbar, and rejected a deliberately perturbed version.

```
python3 -m unittest discover -s tests   ->  Ran 24 tests, OK
actionlint .github/workflows/*.yml      ->  clean
```

The final end-to-end mise check can only run once this is on the default
branch, since mise reads the `HEAD` raw URL. I'll verify it after merge.
