### PR TITLE
chore(deps): update checkout action to v7

### DIFF
--- a/.github/workflows/update-cask-api.yml
+++ b/.github/workflows/update-cask-api.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout tap repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tap repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Git
         run: |


### PR DESCRIPTION
Refresh both automation workflows from `actions/checkout@v6` to `actions/checkout@v7` (currently v7.0.1, `3d3c42e5aac5ba805825da76410c181273ba90b1`). No formula/cask versions, runtime dependencies, or permissions change.

The major upgrade is compatible with these workflows: v7 still uses Node 24, and its new fork-PR checkout restriction does not affect the formula workflow's default checkout or the cask workflow's explicit `ref: main`. The cask workflow follows a `workflow_dispatch` formula update, not fork PR code. No unsafe-checkout opt-in is needed. Reviewed the [upstream migration notes](https://github.com/actions/checkout/blob/v7.0.1/README.md#whats-new) and [changelog](https://github.com/actions/checkout/blob/v7.0.1/CHANGELOG.md).

Dependency inventory: the two Python scripts use only the standard library; there are no npm, Go, SwiftPM, Cargo, Python dependency manifests, or lockfiles. Homebrew dependency declarations are unversioned. Checkout is the only referenced GitHub Action. No majors were skipped, and no dependency was added or removed. This internal automation update does not require a changelog entry.

### Validation and live proof

This tap has no standalone application build target. Workflow lint and compilation/syntax checks passed for all 26 Ruby formulae/casks and all four Python source/test files. The complete local test suite passed:

```text
$ PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v
Ran 24 tests in 4.349s
OK

$ actionlint .github/workflows/update-cask-api.yml .github/workflows/update-formula.yml
(no output; exit 0)

$ git diff --check
(no output; exit 0)
```

The actual updater downloaded the published Birdclaw tarball and verified its existing checksum; the formula remained byte-for-byte unchanged:

```text
$ env -u GITHUB_TOKEN PYTHONDONTWRITEBYTECODE=1 python3 .github/scripts/update_formula.py --formula birdclaw --tag v0.12.1 --repository steipete/birdclaw --artifact-url 'https://registry.npmjs.org/birdclaw/-/birdclaw-{version}.tgz'
no explicit head; leaving it unchanged
no explicit version; leaving it unchanged
macOS: 23b41ebdf095a611408528526784262c723cc726e91b65ca60599d17644580ba  https://registry.npmjs.org/birdclaw/-/birdclaw-0.12.1.tgz
updated Formula/birdclaw.rb to 0.12.1

$ git diff --exit-code -- Formula/birdclaw.rb
(no output; exit 0)
```

The real generator queried Homebrew for every cask, validated source commit/checksums, and wrote metadata into automatically removed temporary output. The installed tap and source checkout were both at `7889bf1fab7e18b53b51e1bd90675f108600a1b2`:

```sh
PYTHONDONTWRITEBYTECODE=1 python3 - <<'PY'
import importlib.util
import json
import pathlib
import shutil
import tempfile
spec = importlib.util.spec_from_file_location('cask_api', '.github/scripts/generate_cask_api.py')
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)
with tempfile.TemporaryDirectory(prefix='deps-refresh-live-', dir='.git') as directory:
    root = pathlib.Path(directory)
    shutil.copytree('Casks', root / 'Casks')
    paths = module.generate(root=root, source_head=module.git_head(pathlib.Path.cwd()))
    for path in paths:
        metadata = json.loads(path.read_text())
        print(f"verified live Homebrew metadata: {metadata['full_token']} {metadata['version']}")
    print(f'Live cask generation passed: {len(paths)} casks; source commit and checksums verified')
PY
```

```text
generated api/cask/blackbar.json
generated api/cask/codexbar.json
generated api/cask/nameplate.json
generated api/cask/repobar.json
generated api/cask/trimmy.json
verified live Homebrew metadata: steipete/tap/blackbar 0.2.5
verified live Homebrew metadata: steipete/tap/codexbar 0.56.1
verified live Homebrew metadata: steipete/tap/nameplate 0.3.1
verified live Homebrew metadata: steipete/tap/repobar 0.8.3
verified live Homebrew metadata: steipete/tap/trimmy 0.10.1
Live cask generation passed: 5 casks; source commit and checksums verified
```

### CI reasoning

Default-branch automation was green before this branch and remains green: [Update Formula](https://github.com/steipete/homebrew-tap/actions/runs/33307455488) and [Update Cask API Metadata](https://github.com/steipete/homebrew-tap/actions/runs/33307464012) succeeded. These are publication/operations workflows with repository-write permissions, not build/test CI. Neither runs on pull requests, so there are no Actions build/test checks for this PR. The GitGuardian Security Checks integration passed on the PR. The publication workflows were not dispatched for validation because they can commit and push to `main`.

The released checkout commit's [upstream build and integration tests](https://github.com/actions/checkout/actions/runs/29604990390) passed, including Ubuntu and macOS, the two runner families used here. Local proof above covers the tap scripts. Execution of the updated publication workflows on GitHub remains a post-merge check for the maintainer; this PR does not claim a new default-branch run or merge itself.

Codex autoreview completed with `scoped-clean`: no accepted/actionable findings at the default P0 scope.
