### PR TITLE
fix(casks): remove deprecated URL verification parameters

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tap Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: macos-latest
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Test release and metadata tooling
+        run: python3 -B -m unittest discover -s tests -v
+
+      - name: Check cask style
+        run: brew style Casks/*.rb
+
+      - name: Load casks with Homebrew and generate API metadata
+        run: |
+          brew tap --custom-remote steipete/tap "$GITHUB_WORKSPACE"
+          python3 -B .github/scripts/generate_cask_api.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Remove deprecated Homebrew URL verification parameters from the BlackBar, CodexBar, Nameplate, and RepoBar casks. Thanks @danielbrodie for the fix and @rudironsoni for reporting.

--- a/Casks/blackbar.rb
+++ b/Casks/blackbar.rb
@@ -2,8 +2,7 @@ cask "blackbar" do
   version "0.2.5"
   sha256 "068ff4ceb559a357f142b693fca2ffbc05057f5b9a2f634eb35693c252e4b5bc"
 
-  url "https://github.com/steipete/BlackBar/releases/download/v#{version}/BlackBar-#{version}.zip",
-      verified: "github.com/steipete/BlackBar/"
+  url "https://github.com/steipete/BlackBar/releases/download/v#{version}/BlackBar-#{version}.zip"
   name "BlackBar"
   desc "Menu bar app for Blacksmith CI status and live vCPU usage"
   homepage "https://black.bar/"

--- a/Casks/codexbar.rb
+++ b/Casks/codexbar.rb
@@ -2,8 +2,7 @@ cask "codexbar" do
   version "0.56.6"
   sha256 "4d10fb8e2ed7b1dca43b4fb375ce7aa8f6b0a382ae94a05c190925d40a72c00d"
 
-  url "https://github.com/steipete/CodexBar/releases/download/v#{version}/CodexBar-macos-universal-#{version}.zip",
-      verified: "github.com/steipete/CodexBar/"
+  url "https://github.com/steipete/CodexBar/releases/download/v#{version}/CodexBar-macos-universal-#{version}.zip"
   name "CodexBar"
   desc "Menu bar usage monitor for Codex and Claude"
   homepage "https://codexbar.app/"

--- a/Casks/nameplate.rb
+++ b/Casks/nameplate.rb
@@ -2,8 +2,7 @@ cask "nameplate" do
   version "0.3.1"
   sha256 "639e9eff1fc3e57a351a9cae4dc31eea5b3d6b730b5e21609eeebf48350f936f"
 
-  url "https://github.com/steipete/Nameplate/releases/download/v#{version}/Nameplate-#{version}.zip",
-      verified: "github.com/steipete/Nameplate/"
+  url "https://github.com/steipete/Nameplate/releases/download/v#{version}/Nameplate-#{version}.zip"
   name "Nameplate"
   desc "Brand every computer in your fleet with click-through identity overlays"
   homepage "https://nameplate.sh/"

--- a/Casks/repobar.rb
+++ b/Casks/repobar.rb
@@ -2,8 +2,7 @@ cask "repobar" do
   version "0.8.3"
   sha256 "5f7401ee36f4d1048548204fb540562ccb6d4101b3da109c1fc6914095c855e8"
 
-  url "https://github.com/steipete/RepoBar/releases/download/v#{version}/RepoBar-#{version}.zip",
-      verified: "github.com/steipete/RepoBar/"
+  url "https://github.com/steipete/RepoBar/releases/download/v#{version}/RepoBar-#{version}.zip"
   name "RepoBar"
   desc "Menu bar dashboard for GitHub repository health"
   homepage "https://repobar.app/"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ python3 .github/scripts/generate_cask_api.py
 
 OpenClaw-owned formulae live in `openclaw/tap`; migrated names are listed in `tap_migrations.json`.
 
+## Validation
+
+Run `python3 -B -m unittest discover -s tests -v` and `brew style Casks/*.rb` before submitting changes. The `Tap Tests` workflow also loads every cask with Homebrew and generates its API metadata on pull requests and pushes to `main`.
+
+Use a plain `url` stanza for casks; Homebrew handles URL verification by default and has deprecated the `verified:` parameter.
+
 ## Update / Uninstall
 
 ```bash

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -350,8 +350,7 @@ end
   version "0.26.1"
   sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-  url "https://github.com/steipete/CodexBar/releases/download/v#{version}/CodexBar-macos-universal-#{version}.zip",
-      verified: "github.com/steipete/CodexBar/"
+  url "https://github.com/steipete/CodexBar/releases/download/v#{version}/CodexBar-macos-universal-#{version}.zip"
 end
 '''
 
@@ -365,7 +364,7 @@ end
 
         self.assertIn('version "0.27.0"', updated)
         self.assertIn('sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"', updated)
-        self.assertIn("CodexBar-macos-universal-#{version}.zip", updated)
+        self.assertIn('url "https://github.com/steipete/CodexBar/releases/download/v#{version}/CodexBar-macos-universal-#{version}.zip"\n', updated)
 
     def test_arm64_macos_artifact_keeps_top_level_arch_restriction(self) -> None:
         text = '''class Sonoscli < Formula


### PR DESCRIPTION
Homebrew now warns whenever it loads a cask URL with the deprecated `verified:` parameter. Remove it from CodexBar, BlackBar, Nameplate, and RepoBar, preserving their release URLs, checksums, versions, and installation metadata. Thanks @danielbrodie for the fix and @rudironsoni for reporting the CodexBar warning.

Update the release-updater test to preserve the plain interpolated URL stanza, document current cask syntax, and add PR validation for Python tests, cask style, and real Homebrew metadata generation.

Validation: all 24 Python tests pass, all five casks pass `brew style`, and `actionlint` passes. A real before/after run using Homebrew revision `1490a40d90a58dd7b0d7149aa42b520a50e3e17b` (the reporter's revision) emitted four deprecated-parameter warnings before the fix and none afterward. All five casks retain identical installation metadata and generate valid API metadata. Exact-head CI and autoreview results are recorded in the verification comment.

Closes #58.
